### PR TITLE
Refactor cache logic for configurable backends

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -4,6 +4,9 @@
 Settings
 ========
 
+``RATELIMIT_BACKEND``:
+    The backend which holds the current access rates (defaults to
+    ``ratelimit.backends.cache.CacheBackend``)
 ``RATELIMIT_CACHE_PREFIX``:
     An optional cache prefix for ratelimit keys (in addition to the
     ``PREFIX`` value). *rl:*

--- a/ratelimit/backends/__init__.py
+++ b/ratelimit/backends/__init__.py
@@ -1,0 +1,30 @@
+import hashlib
+
+__all__ = ['RateLimitBackend']
+
+
+class RateLimitBackend(object):
+    """ Base class for all rate limit backends """
+
+    def _get_keys(self, request, ip=True, field=None, keyfuncs=None):
+        keys = []
+        if ip:
+            keys.append('ip:' + request.META['REMOTE_ADDR'])
+        if field is not None:
+            if not isinstance(field, (list, tuple)):
+                field = [field]
+            for f in field:
+                val = getattr(request, request.method).get(f, '').encode('utf-8')
+                val = hashlib.sha1(val).hexdigest()
+                keys.append(u'field:%s:%s' % (f, val))
+        if keyfuncs:
+            if not isinstance(keyfuncs, (list, tuple)):
+                keyfuncs = [keyfuncs]
+            for k in keyfuncs:
+                keys.append(k(request))
+        return keys
+
+
+    def hit(self, request, ip, field, keys, period):
+        """ Records a hit and returns the current coutns """
+        raise NotImplemented

--- a/ratelimit/backends/cache.py
+++ b/ratelimit/backends/cache.py
@@ -1,0 +1,38 @@
+import hashlib
+
+from django.conf import settings
+from django.core.cache import get_cache
+
+from ratelimit.backends import RateLimitBackend
+
+__all__ = ['CacheBackend']
+
+CACHE_PREFIX = getattr(settings, 'RATELIMIT_CACHE_PREFIX', 'rl:')
+
+
+class CacheBackend(RateLimitBackend):
+    """ Rate limit backend that uses Django's cache """
+
+    def __init__(self):
+        cache = getattr(settings, 'RATELIMIT_USE_CACHE', 'default')
+        self.cache = get_cache(cache)
+
+
+    def _incr(self, keys, timeout=60):
+        # Yes, this is a race condition, but memcached.incr doesn't reset the
+        # timeout.
+        keys = [CACHE_PREFIX + k for k in keys]
+        counts = self.cache.get_many(keys)
+        for key in keys:
+            if key in counts:
+                counts[key] += 1
+            else:
+                counts[key] = 1
+        self.cache.set_many(counts, timeout=timeout)
+        return counts
+
+
+    def hit(self, request, ip, field, keys, period):
+        _keys = self._get_keys(request, ip, field, keys)
+        counts = self._incr(_keys, period)
+        return counts

--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -1,9 +1,8 @@
-import hashlib
 import re
 from functools import wraps
 
 from django.conf import settings
-from django.core.cache import get_cache
+from django.utils.importlib import import_module
 
 from ratelimit.exceptions import Ratelimited
 
@@ -11,7 +10,6 @@ from ratelimit.exceptions import Ratelimited
 __all__ = ['ratelimit']
 
 RATELIMIT_ENABLE = getattr(settings, 'RATELIMIT_ENABLE', True)
-CACHE_PREFIX = getattr(settings, 'RATELIMIT_CACHE_PREFIX', 'rl:')
 
 _PERIODS = {
     's': 1,
@@ -40,36 +38,24 @@ def _split_rate(rate):
     return count, time
 
 
-def _get_keys(request, ip=True, field=None, keyfuncs=None):
-    keys = []
-    if ip:
-        keys.append('ip:' + request.META['REMOTE_ADDR'])
-    if field is not None:
-        if not isinstance(field, (list, tuple)):
-            field = [field]
-        for f in field:
-            val = getattr(request, request.method).get(f, '').encode('utf-8')
-            val = hashlib.sha1(val).hexdigest()
-            keys.append(u'field:%s:%s' % (f, val))
-    if keyfuncs:
-        if not isinstance(keyfuncs, (list, tuple)):
-            keyfuncs = [keyfuncs]
-        for k in keyfuncs:
-            keys.append(k(request))
-    return [CACHE_PREFIX + k for k in keys]
+def _get_backend():
+    """ Loads and instantiates the backendd
 
+    The ``RATELIMIT_BACKEND`` setting must be set to the full name of the
+    backend class.
 
-def _incr(cache, keys, timeout=60):
-    # Yes, this is a race condition, but memcached.incr doesn't reset the
-    # timeout.
-    counts = cache.get_many(keys)
-    for key in keys:
-        if key in counts:
-            counts[key] += 1
-        else:
-            counts[key] = 1
-    cache.set_many(counts, timeout=timeout)
-    return counts
+    """
+    RATELIMIT_BACKEND = getattr(settings, 'RATELIMIT_BACKEND',
+                                'ratelimit.backends.cache.CacheBackend')
+
+    parts = RATELIMIT_BACKEND.split('.')
+    modname = '.'.join(parts[:-1])
+    clsname = parts[-1]
+
+    mod = import_module(modname)
+    cls = getattr(mod, clsname)
+
+    return cls()
 
 
 def ratelimit(ip=True, block=False, method=['POST'], field=None, rate='5/m',
@@ -79,14 +65,13 @@ def ratelimit(ip=True, block=False, method=['POST'], field=None, rate='5/m',
 
         @wraps(fn)
         def _wrapped(request, *args, **kw):
-            cache = getattr(settings, 'RATELIMIT_USE_CACHE', 'default')
-            cache = get_cache(cache)
+            backend = _get_backend()
 
             request.limited = False
             if (RATELIMIT_ENABLE and _method_match(request, method) and
                     (skip_if is None or not skip_if(request))):
-                _keys = _get_keys(request, ip, field, keys)
-                counts = _incr(cache, _keys, period)
+
+                counts = backend.hit(request, ip, field, keys, period)
                 if any([c > count for c in counts.values()]):
                     request.limited = True
                     if block:


### PR DESCRIPTION
I plan to implement rate-limiting using a redis backend for a distributed setup with local caches.

As a preparation for that I've refactored the current cache-related code into a `CacheBackend` class, and added a setting to specify a custom backend (defaults to the cache backend of course).
