### PR TITLE
Fix version pinning in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 env:
  - DJANGO="Django>=1.4,<1.4.99"
  - DJANGO="Django>=1.5,<1.5.99"
- - DJANGO="git+https://github.com/django/django.git@1.6c1#egg=Django
+ - DJANGO="git+https://github.com/django/django.git@1.6c1#egg=Django"
 python:
  - "2.6"
  - "2.7"


### PR DESCRIPTION
The django repo maintains branches for each minor version.  Since we are using the git repo for travis builds now we should use them vs maintaining a list of the latest micro versions.
