### PR TITLE
Add python 3.3 testing to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: python
 env:
- - DJANGO="Django>=1.4,<1.4.99"
- - DJANGO="Django>=1.5,<1.5.99"
- - DJANGO="git+https://github.com/django/django.git@1.6c1#egg=Django"
+ - DJANGO_VERSION=1.4
+ - DJANGO_VERSION=1.5
+ - DJANGO_VERSION=1.6
 python:
  - "2.6"
  - "2.7"
  - "3.3"
 install:
- - pip install -q ${DJANGO}
+ - pip install -q "Django>=${DJANGO_VERSION},<${DJANGO_VERSION}.99"
 script: ./run.sh test
 matrix:
   exclude:
     - python: 3.3
-      env: DJANGO="Django>=1.4,<1.4.99"
+      env: DJANGO_VERSION=1.4


### PR DESCRIPTION
Tox is already setup to run the tests on python 3.3 for only django 1.5 and 1.6.  Using matrix exclude we can get travis to only run 1.5/1.6 on python 3.3 as well.
