### PR TITLE
pick up IP from X-Forwarded-for first

### DIFF
--- a/ratelimit/helpers.py
+++ b/ratelimit/helpers.py
@@ -33,11 +33,16 @@ def _split_rate(rate):
         time = time * int(multi)
     return count, time
 
+def _get_client_address(environ):
+    try:
+        return environ['HTTP_X_FORWARDED_FOR'].split(',')[-1].strip()
+    except KeyError:
+        return environ['REMOTE_ADDR']
 
 def _get_keys(request, ip=True, field=None, keyfuncs=None):
     keys = []
     if ip:
-        keys.append('ip:' + request.META['REMOTE_ADDR'])
+        keys.append('ip:' + _get_client_address(request.META))
     if field is not None:
         if not isinstance(field, (list, tuple)):
             field = [field]


### PR DESCRIPTION
The REMOTE_ADDR isn't guaranteed to be the IP of the remote user but is often
the IP of the web server that sits in front of Django. For example, a load
balancer. Instead, the X-FORWARDED-FOR header is usually the IP of the remote
user.
