### PR TITLE
"extracted" cache key building from is_ratelimited to separate method to allow rate limit resetting.

### DIFF
--- a/ratelimit/utils.py
+++ b/ratelimit/utils.py
@@ -169,7 +169,11 @@ def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
 
     cache.add(cache_key, 0)
     if increment:
-        count = cache.incr(cache_key)
+        try:
+            count = cache.incr(cache_key)
+        except ValueError:
+            # key already expired or removed because we lack memory
+            count = 1
     else:
         count = cache.get(cache_key)
     limited = count > limit

--- a/ratelimit/utils.py
+++ b/ratelimit/utils.py
@@ -97,8 +97,21 @@ def _make_cache_key(group, rate, value, methods):
     return prefix + hashlib.md5(u''.join(parts).encode('utf-8')).hexdigest()
 
 
-def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
-                   method=ALL, increment=False):
+def _prepare_rate(rate, group, request):
+    if callable(rate):
+        rate = rate(group, request)
+    return rate
+
+
+def get_ratelimit_cache():
+    cache_name = getattr(settings, 'RATELIMIT_USE_CACHE', 'default')
+    # TODO: Django 1.7+
+    cache = get_cache(cache_name)
+    return cache
+
+
+def get_cache_key_for_request(request, group=None, fn=None, key=None,
+                              rate=None, method=ALL):
     if not key:
         raise ImproperlyConfigured('Ratelimit key must be specified')
     if group is None:
@@ -108,27 +121,7 @@ def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
             parts = (fn.__module__, fn.__name__)
         group = '.'.join(parts)
 
-    if not getattr(settings, 'RATELIMIT_ENABLE', True):
-        request.limited = False
-        return False
-
-    if not _method_match(request, method):
-        return False
-
-    old_limited = getattr(request, 'limited', False)
-
-    if callable(rate):
-        rate = rate(group, request)
-
-    if rate is None:
-        request.limited = old_limited
-        return False
-
-    limit, period = _split_rate(rate)
-
-    cache_name = getattr(settings, 'RATELIMIT_USE_CACHE', 'default')
-    # TODO: Django 1.7+
-    cache = get_cache(cache_name)
+    rate = _prepare_rate(rate, group, request)
 
     if callable(key):
         value = key(group, request)
@@ -147,7 +140,33 @@ def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
         raise ImproperlyConfigured(
             'Could not understand ratelimit key: %s' % key)
 
-    cache_key = _make_cache_key(group, rate, value, method)
+    return _make_cache_key(group, rate, value, method)
+
+
+def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
+                   method=ALL, increment=False):
+    if not key:
+        raise ImproperlyConfigured('Ratelimit key must be specified')
+    if not getattr(settings, 'RATELIMIT_ENABLE', True):
+        request.limited = False
+        return False
+
+    if not _method_match(request, method):
+        return False
+
+    old_limited = getattr(request, 'limited', False)
+
+    rate = _prepare_rate(rate, group, request)
+    if rate is None:
+        request.limited = old_limited
+        return False
+    limit, period = _split_rate(rate)
+
+    cache = get_ratelimit_cache()
+    cache_key = get_cache_key_for_request(
+        request, group, fn, key, rate, method,
+    )
+
     cache.add(cache_key, 0)
     if increment:
         count = cache.incr(cache_key)


### PR DESCRIPTION
This will allow to manually reset rate limits for some request. Example
usage:

1. captcha is shown when request.limited is True
2. after captcha is passed next request ignores rate limits but following
requests will still increment "rate usage" above limit
3. to fix problem above we can delete cache entry after succesfull
captcha:

```python
recaptcha_response = request.POST.get('g-recaptcha-response', None)
if recaptcha_response:
    try:
        recaptcha_status = requests.post(
            'https://www.google.com/recaptcha/api/siteverify',
            data={
                'secret': settings.RECAPTCHA_SECRET_KEY,
                'response': recaptcha_response,
            },
        ).json()
	request.recaptcha_success = recaptcha_status.get('success', False)
	if request.recaptcha_success:
	    ratelimit.utils.get_cache().delete(ratelimit.utils.get_cache_key_for_request(request, group, fn, key,rate,))
```