### PR TITLE
Replaced Mixin config generator to improve inheritance

### DIFF
--- a/ratelimit/mixins.py
+++ b/ratelimit/mixins.py
@@ -40,10 +40,16 @@ class RatelimitMixin(object):
     UNSAFE = UNSAFE
 
     def get_ratelimit_config(self):
+        # Ensures that the ratelimit_key is called as a function instead of a
+        # method if it is a callable (ie self is not passed).
+        if callable(self.ratelimit_key):
+            self.ratelimit_key = self.ratelimit_key.__func__
         return dict(
-            (k[len("ratelimit_"):], v)
-            for k, v in vars(self.__class__).items()
-            if k.startswith("ratelimit")
+            group=self.ratelimit_group,
+            key=self.ratelimit_key,
+            rate=self.ratelimit_rate,
+            block=self.ratelimit_block,
+            method=self.ratelimit_method,
         )
 
     def dispatch(self, *args, **kwargs):


### PR DESCRIPTION
The way the config was generated did not allow for class based views to
inherit from a view that itself inherited from RatelimitMixin without
redefining the Ratelimit properties.  

This is because `vars(self.__class__)` only shows properties set directly on that class, not on its parents. 

This change restores some of the benefit of CBVS in that a class can be created setting some ratelimit
defaults, and then used as a mixin with other CBVS.