### PR TITLE
Test on Django 1.8, clean up Django checks and deprecation warnings.

### DIFF
--- a/ratelimit/compat.py
+++ b/ratelimit/compat.py
@@ -5,3 +5,9 @@ try:
         return caches[name]
 except ImportError:  # Django <1.7
     from django.core.cache import get_cache
+
+
+try:
+    from importlib import import_module
+except ImportError:  # Python 2.6
+    from django.utils.importlib import import_module

--- a/ratelimit/compat.py
+++ b/ratelimit/compat.py
@@ -1,0 +1,7 @@
+try:
+    from django.core.cache import caches
+
+    def get_cache(name):
+        return caches[name]
+except ImportError:  # Django <1.7
+    from django.core.cache import get_cache

--- a/ratelimit/compat.py
+++ b/ratelimit/compat.py
@@ -4,10 +4,10 @@ try:
     def get_cache(name):
         return caches[name]
 except ImportError:  # Django <1.7
-    from django.core.cache import get_cache
+    from django.core.cache import get_cache  # noqa
 
 
 try:
     from importlib import import_module
 except ImportError:  # Python 2.6
-    from django.utils.importlib import import_module
+    from django.utils.importlib import import_module  # noqa

--- a/ratelimit/utils.py
+++ b/ratelimit/utils.py
@@ -5,9 +5,8 @@ import zlib
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
 
-from ratelimit.compat import get_cache
+from ratelimit.compat import import_module, get_cache
 from ratelimit import ALL, UNSAFE
 
 

--- a/ratelimit/utils.py
+++ b/ratelimit/utils.py
@@ -4,10 +4,10 @@ import time
 import zlib
 
 from django.conf import settings
-from django.core.cache import get_cache
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.importlib import import_module
 
+from ratelimit.compat import get_cache
 from ratelimit import ALL, UNSAFE
 
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -19,3 +19,6 @@ DATABASES = {
         'NAME': 'test.db',
     },
 }
+
+# silence system check about unset `MIDDLEWARE_CLASSES`
+SILENCED_SYSTEM_CHECKS = ['1_7.W001']

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,10 @@ commands = ./run.sh test
 
 # python 3.4
 
+[testenv:py34-1.8]
+basepython = python3.4
+deps = Django>=1.8,<1.8.99
+
 [testenv:py34-1.7]
 basepython = python3.4
 deps = Django>=1.7,<1.7.99
@@ -17,6 +21,10 @@ deps = Django>=1.5,<1.5.99
 
 # python 3.3
 
+[testenv:py33-1.8]
+basepython = python3.3
+deps = Django>=1.8,<1.8.99
+
 [testenv:py33-1.7]
 basepython = python3.3
 deps = Django>=1.7,<1.7.99
@@ -30,6 +38,10 @@ basepython = python3.3
 deps = Django>=1.5,<1.5.99
 
 # python 2.7
+
+[testenv:py27-1.8]
+basepython = python2.7
+deps = Django>=1.7,<1.7.99
 
 [testenv:py27-1.7]
 basepython = python2.7


### PR DESCRIPTION
This adds Django 1.8 to the tox test matrix, and adjusts several uses of deprecated APIs to prefer the superseding API in a recent-enough Python or Django version. After this pull request tox runs warning-free.