### PR TITLE
Add docs for what I believe is a feature (stacked decorators with same key value)

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -99,12 +99,12 @@ Examples
         # Use multiple keys by stacking decorators.
         return HttpResponse()
 
-    @ratelimit(key='get:username', rate='5/m')
-    @ratelimit(key='post:username', rate='5/m')
-    def login(request):
-        # These two decorators combine to form one rate limit: the same
-        # username can only be tried 5 times a minute, regardless of the
-        # request method (GET or POST)
+    @ratelimit(key='get:q', rate='5/m')
+    @ratelimit(key='post:q', rate='5/m')
+    def search(request):
+        # These two decorators combine to form one rate limit: the same search
+        # query can only be tried 5 times a minute, regardless of the request
+        # method (GET or POST)
         return HttpResponse()
 
     @ratelimit(key='ip', rate='4/h')

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -99,6 +99,14 @@ Examples
         # Use multiple keys by stacking decorators.
         return HttpResponse()
 
+    @ratelimit(key='get:username', rate='5/m')
+    @ratelimit(key='post:username', rate='5/m')
+    def login(request):
+        # These two decorators combine to form one rate limit: the same
+        # username can only be tried 5 times a minute, regardless of the
+        # request method (GET or POST)
+        return HttpResponse()
+
     @ratelimit(key='ip', rate='4/h')
     def slow(request):
         # Allow 4 reqs/hour.


### PR DESCRIPTION
I have an API that can be accessed via both GET and POST. I want to rate-limit based on a value that can be supplied in the same key with either method.

I read the code and it looks like this works because the key accessor is not part of the cache key; only the key value is used.

I added an example demonstrating this behavior. If it works as I think it does, this would have been a helpful example for me. Thanks for reading!