### PR TITLE
Slightly better integration with Django Rest Framework

### DIFF
--- a/ratelimit/contrib/drf/__init__.py
+++ b/ratelimit/contrib/drf/__init__.py
@@ -1,0 +1,10 @@
+
+from ratelimit.exceptions import Ratelimited
+import rest_framework.views
+import rest_framework.exceptions
+
+def exception_handler(exc, context):
+    if isinstance(exc, Ratelimited):
+        exc = rest_framework.exceptions.Throttled()
+
+    return rest_framework.views.exception_handler(exc, context)

--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -2,25 +2,41 @@ from __future__ import absolute_import
 
 from functools import wraps
 
-from django.http import HttpRequest
-
 from ratelimit import ALL, UNSAFE
 from ratelimit.exceptions import Ratelimited
 from ratelimit.utils import is_ratelimited
 
+try:
+    from rest_framework.exceptions import Throttled
+    Ratelimited = Throttled
+except ImportError:
+    pass
 
 __all__ = ['ratelimit']
 
+def _looks_like_HttpRequest(thing):
+    # Django Rest Framework uses a Request class that is not a subclass of
+    # Django core's HttpRequest, so we duck-type the request object
+    try:
+        thing.META.get('REQUEST_METHOD')
+        thing.method
+        thing.path
+        thing.scheme
+        return True
+    except AttributeError:
+        return False
 
 def ratelimit(group=None, key=None, rate=None, method=ALL, block=False):
     def decorator(fn):
         @wraps(fn)
         def _wrapped(*args, **kw):
             # Work as a CBV method decorator.
-            if isinstance(args[0], HttpRequest):
+            if _looks_like_HttpRequest(args[0]):
                 request = args[0]
-            else:
+            elif len(args) >= 2 and _looks_like_HttpRequest(args[1]):
                 request = args[1]
+            else:
+                raise ValueError('ratelimit decorator wrapped around something that does not look like a view')
             request.limited = getattr(request, 'limited', False)
             ratelimited = is_ratelimited(request=request, group=group, fn=fn,
                                          key=key, rate=rate, method=method,

--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -6,12 +6,6 @@ from ratelimit import ALL, UNSAFE
 from ratelimit.exceptions import Ratelimited
 from ratelimit.utils import is_ratelimited
 
-try:
-    from rest_framework.exceptions import Throttled
-    Ratelimited = Throttled
-except ImportError:
-    pass
-
 __all__ = ['ratelimit']
 
 def _looks_like_HttpRequest(thing):
@@ -30,7 +24,7 @@ def ratelimit(group=None, key=None, rate=None, method=ALL, block=False):
     def decorator(fn):
         @wraps(fn)
         def _wrapped(*args, **kw):
-            # Work as a CBV method decorator.
+            # Work as a function-based view decorator or CBV method decorator.
             if _looks_like_HttpRequest(args[0]):
                 request = args[0]
             elif len(args) >= 2 and _looks_like_HttpRequest(args[1]):


### PR DESCRIPTION
Here's another idea. Probably could be implemented a little better; please let me know what you think.

These two changes allow the decorator to be used after `@api_view()` decorator and allow DRF to generate a 429 response when the ratelimit is exceeded.
