### PR TITLE
Fix for cache keys being evicted between add and incr/get on memcached

### DIFF
--- a/ratelimit/utils.py
+++ b/ratelimit/utils.py
@@ -153,9 +153,16 @@ def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
         count = initial_value
     else:
         if increment:
-            count = cache.incr(cache_key)
+            try:
+                count = cache.incr(cache_key)
+            except ValueError:  # key was evicted from cache since add()
+                cache.set(cache_key, initial_value)
+                count = initial_value
         else:
             count = cache.get(cache_key)
+            if count is None:  # key was evicted from cache since add()
+                cache.add(cache_key, initial_value)
+                count = initial_value
     limited = count > limit
     if increment:
         request.limited = old_limited or limited


### PR DESCRIPTION
Similar to #78 but with tests, see explanation on #78 