### PR TITLE
Support missing headers

### DIFF
--- a/ratelimit/tests.py
+++ b/ratelimit/tests.py
@@ -157,6 +157,7 @@ class RatelimitTests(TestCase):
         req.META['HTTP_X_REAL_IP'] = '1.2.3.4'
 
         @ratelimit(key='header:x-real-ip', rate='1/m')
+        @ratelimit(key='header:x-missing-header', rate='1/m')
         def view(request):
             return request.limited
 

--- a/ratelimit/utils.py
+++ b/ratelimit/utils.py
@@ -35,7 +35,7 @@ _SIMPLE_KEYS = {
 
 def get_header(request, header):
     key = 'HTTP_' + header.replace('-', '_').upper()
-    return request.META[key]
+    return request.META.get(key, '')
 
 
 _ACCESSOR_KEYS = {


### PR DESCRIPTION
Currently the decorator raises a KeyError if the User Agent header isn't present, this patch fixes the issue