### PR TITLE
Cope with cache connection errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ python:
  - "3.4"
  - "pypy"
 install:
+ - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install -q python-memcached>=1.57; fi
+ - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install -q python3-memcached>=1.51; fi
+ - if [[ $TRAVIS_PYTHON_VERSION == pypy ]]; then pip install -q python-memcached>=1.57; fi
  - pip install -q "Django>=${DJANGO_VERSION},<${DJANGO_VERSION}.99" flake8
 script:
  - ./run.sh test

--- a/ratelimit/utils.py
+++ b/ratelimit/utils.py
@@ -153,9 +153,12 @@ def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
         count = initial_value
     else:
         if increment:
-            count = cache.incr(cache_key)
+            try:
+                count = cache.incr(cache_key)
+            except ValueError:
+                count = 0
         else:
-            count = cache.get(cache_key)
+            count = cache.get(cache_key) or 0
     limited = count > limit
     if increment:
         request.limited = old_limited or limited

--- a/test_settings.py
+++ b/test_settings.py
@@ -11,6 +11,10 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
         'LOCATION': 'ratelimit-tests',
     },
+    'connection-errors': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': 'test-connection-errors',
+    },
 }
 
 DATABASES = {

--- a/tox.ini
+++ b/tox.ini
@@ -5,70 +5,102 @@ commands = ./run.sh test
 
 [testenv:py34-1.8]
 basepython = python3.4
-deps = Django>=1.8,<1.8.99
+deps =
+    Django>=1.8,<1.8.99
+    python3-memcached>=1.51
 
 [testenv:py34-1.7]
 basepython = python3.4
-deps = Django>=1.7,<1.7.99
+deps =
+    Django>=1.7,<1.7.99
+    python3-memcached>=1.51
 
 [testenv:py34-1.6]
 basepython = python3.4
-deps = Django>=1.6,<1.6.99
+deps =
+    Django>=1.6,<1.6.99
+    python3-memcached>=1.51
 
 [testenv:py34-1.5]
 basepython = python3.4
-deps = Django>=1.5,<1.5.99
+deps =
+    Django>=1.5,<1.5.99
+    python3-memcached>=1.51
 
 # python 3.3
 
 [testenv:py33-1.8]
 basepython = python3.3
-deps = Django>=1.8,<1.8.99
+deps =
+    Django>=1.8,<1.8.99
+    python3-memcached>=1.51
 
 [testenv:py33-1.7]
 basepython = python3.3
-deps = Django>=1.7,<1.7.99
+deps =
+    Django>=1.7,<1.7.99
+    python3-memcached>=1.51
 
 [testenv:py33-1.6]
 basepython = python3.3
-deps = Django>=1.6,<1.6.99
+deps =
+    Django>=1.6,<1.6.99
+    python3-memcached>=1.51
 
 [testenv:py33-1.5]
 basepython = python3.3
-deps = Django>=1.5,<1.5.99
+deps =
+    Django>=1.5,<1.5.99
+    python3-memcached>=1.51
 
 # python 2.7
 
 [testenv:py27-1.8]
 basepython = python2.7
-deps = Django>=1.7,<1.7.99
+deps =
+    Django>=1.7,<1.7.99
+    python-memcached>=1.57
 
 [testenv:py27-1.7]
 basepython = python2.7
-deps = Django>=1.7,<1.7.99
+deps =
+    Django>=1.7,<1.7.99
+    python-memcached>=1.57
 
 [testenv:py27-1.6]
 basepython = python2.7
-deps = Django>=1.6,<1.6.99
+deps =
+    Django>=1.6,<1.6.99
+    python-memcached>=1.57
 
 [testenv:py27-1.5]
 basepython = python2.7
-deps = Django>=1.5,<1.5.99
+deps =
+    Django>=1.5,<1.5.99
+    python-memcached>=1.57
 
 [testenv:py27-1.4]
 basepython = python2.7
-deps = Django>=1.4,<1.4.99
+deps =
+    Django>=1.4,<1.4.99
+    python-memcached>=1.57
 
 # python 2.6
 
 [testenv:py26-1.6]
 basepython = python2.6
-deps = Django>=1.6,<1.6.99
+deps =
+    Django>=1.6,<1.6.99
+    python-memcached>=1.57
 
 [testenv:py26-1.5]
 basepython = python2.6
-deps = Django>=1.5,<1.5.99
+deps =
+    Django>=1.5,<1.5.99
+    python-memcached>=1.57
 
 [testenv:py26-1.4]
 basepython = python2.6
-deps = Django>=1.4,<1.4.99
+deps =
+    Django>=1.4,<1.4.99
+    python-memcached>=1.57


### PR DESCRIPTION
If a memcached were to become unavailable, pages using the decorator would start throwing errors. This change copes with these errors and keeps pages available.