### PR TITLE
Simplify tox.ini to generate all environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,106 +1,12 @@
+[tox]
+envlist =
+    py27-django{17,18,19},
+    py{33,34}-django{17,18,19}
+
 [testenv]
+deps =
+    py{26,27}: python-memcached>=1.57
+    py{33,34}: python3-memcached>=1.51
+    django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
 commands = ./run.sh test
-
-# python 3.4
-
-[testenv:py34-1.8]
-basepython = python3.4
-deps =
-    Django>=1.8,<1.8.99
-    python3-memcached>=1.51
-
-[testenv:py34-1.7]
-basepython = python3.4
-deps =
-    Django>=1.7,<1.7.99
-    python3-memcached>=1.51
-
-[testenv:py34-1.6]
-basepython = python3.4
-deps =
-    Django>=1.6,<1.6.99
-    python3-memcached>=1.51
-
-[testenv:py34-1.5]
-basepython = python3.4
-deps =
-    Django>=1.5,<1.5.99
-    python3-memcached>=1.51
-
-# python 3.3
-
-[testenv:py33-1.8]
-basepython = python3.3
-deps =
-    Django>=1.8,<1.8.99
-    python3-memcached>=1.51
-
-[testenv:py33-1.7]
-basepython = python3.3
-deps =
-    Django>=1.7,<1.7.99
-    python3-memcached>=1.51
-
-[testenv:py33-1.6]
-basepython = python3.3
-deps =
-    Django>=1.6,<1.6.99
-    python3-memcached>=1.51
-
-[testenv:py33-1.5]
-basepython = python3.3
-deps =
-    Django>=1.5,<1.5.99
-    python3-memcached>=1.51
-
-# python 2.7
-
-[testenv:py27-1.8]
-basepython = python2.7
-deps =
-    Django>=1.7,<1.7.99
-    python-memcached>=1.57
-
-[testenv:py27-1.7]
-basepython = python2.7
-deps =
-    Django>=1.7,<1.7.99
-    python-memcached>=1.57
-
-[testenv:py27-1.6]
-basepython = python2.7
-deps =
-    Django>=1.6,<1.6.99
-    python-memcached>=1.57
-
-[testenv:py27-1.5]
-basepython = python2.7
-deps =
-    Django>=1.5,<1.5.99
-    python-memcached>=1.57
-
-[testenv:py27-1.4]
-basepython = python2.7
-deps =
-    Django>=1.4,<1.4.99
-    python-memcached>=1.57
-
-# python 2.6
-
-[testenv:py26-1.6]
-basepython = python2.6
-deps =
-    Django>=1.6,<1.6.99
-    python-memcached>=1.57
-
-[testenv:py26-1.5]
-basepython = python2.6
-deps =
-    Django>=1.5,<1.5.99
-    python-memcached>=1.57
-
-[testenv:py26-1.4]
-basepython = python2.6
-deps =
-    Django>=1.4,<1.4.99
-    python-memcached>=1.57


### PR DESCRIPTION
Simplify the tox.ini using the new features as documented under http://tox.readthedocs.org/en/latest/config.html#complex-factor-conditions .

Test:

Extracting and sorting the testenv headers from before, and adding space, you
get the following 19 lines:

```
[testenv:py26-1.4]
[testenv:py26-1.5]
[testenv:py26-1.6]

[testenv:py27-1.4]
[testenv:py27-1.5]
[testenv:py27-1.6]
[testenv:py27-1.7]
[testenv:py27-1.8]

[testenv:py33-1.5]
[testenv:py33-1.6]
[testenv:py33-1.7]
[testenv:py33-1.8]

[testenv:py34-1.5]
[testenv:py34-1.6]
[testenv:py34-1.7]
[testenv:py34-1.8]
```


Now `tox -l` outputs, with spaces added, the following 19 lines, which I
checked to correspond to the above:

```
py26-django14
py26-django15
py26-django16

py27-django14
py27-django15
py27-django16
py27-django17
py27-django18

py33-django15
py33-django16
py33-django17
py33-django18

py34-django15
py34-django16
py34-django17
py34-django18
```

Also the tests pass.