### PR TITLE
Support for Django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
  - DJANGO_VERSION=1.6
  - DJANGO_VERSION=1.7
  - DJANGO_VERSION=1.8
+ - DJANGO_VERSION=1.9
 python:
  - "2.6"
  - "2.7"
@@ -25,9 +26,13 @@ matrix:
       env: DJANGO_VERSION=1.7
     - python: "3.3"
       env: DJANGO_VERSION=1.4
+    - python: "3.3"
+      env: DJANGO_VERSION=1.9
     - python: "3.4"
       env: DJANGO_VERSION=1.4
     - python: "2.6"
       env: DJANGO_VERSION=1.7
     - python: "2.6"
       env: DJANGO_VERSION=1.8
+    - python: "2.6"
+      env: DJANGO_VERSION=1.9

--- a/ratelimit/middleware.py
+++ b/ratelimit/middleware.py
@@ -1,4 +1,7 @@
-from importlib import import_module
+try:
+    from django.utils.importlib import import_module
+except ImportError:
+    from importlib import import_module
 
 from django.conf import settings
 

--- a/ratelimit/middleware.py
+++ b/ratelimit/middleware.py
@@ -1,5 +1,6 @@
+from importlib import import_module
+
 from django.conf import settings
-from django.utils.importlib import import_module
 
 from ratelimit.exceptions import Ratelimited
 


### PR DESCRIPTION
Django 1.9 no longer has [`utils.importlib`](https://docs.djangoproject.com/en/1.9/internals/deprecation/#deprecation-removed-in-1-9). 

This PR provides alternative imports (i.e. standard library importlib) when Django's utils are not present (as Django 1.9 cannot be used < python 2.7).