### PR TITLE
Add an optional reset callable that indicates whether the current counter should be reset to zero.

### DIFF
--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -12,7 +12,8 @@ from ratelimit.utils import is_ratelimited
 __all__ = ['ratelimit']
 
 
-def ratelimit(group=None, key=None, rate=None, method=ALL, block=False, reset=None):
+def ratelimit(group=None, key=None, rate=None, method=ALL, block=False,
+              reset=None):
     def decorator(fn):
         @wraps(fn)
         def _wrapped(*args, **kw):

--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -12,7 +12,7 @@ from ratelimit.utils import is_ratelimited
 __all__ = ['ratelimit']
 
 
-def ratelimit(group=None, key=None, rate=None, method=ALL, block=False):
+def ratelimit(group=None, key=None, rate=None, method=ALL, block=False, reset=None):
     def decorator(fn):
         @wraps(fn)
         def _wrapped(*args, **kw):
@@ -24,7 +24,7 @@ def ratelimit(group=None, key=None, rate=None, method=ALL, block=False):
             request.limited = getattr(request, 'limited', False)
             ratelimited = is_ratelimited(request=request, group=group, fn=fn,
                                          key=key, rate=rate, method=method,
-                                         increment=True)
+                                         increment=True, reset=reset)
             if ratelimited and block:
                 raise Ratelimited()
             return fn(*args, **kw)

--- a/ratelimit/utils.py
+++ b/ratelimit/utils.py
@@ -97,7 +97,7 @@ def _make_cache_key(group, rate, value, methods):
 
 
 def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
-                   method=ALL, increment=False):
+                   method=ALL, increment=False, reset=None):
     if not key:
         raise ImproperlyConfigured('Ratelimit key must be specified')
     if group is None:
@@ -147,6 +147,12 @@ def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
             'Could not understand ratelimit key: %s' % key)
 
     cache_key = _make_cache_key(group, rate, value, method)
+
+    if reset and callable(reset):
+        should_reset = reset(request)
+        if should_reset:
+            cache.delete(cache_key)
+
     initial_value = 1 if increment else 0
     added = cache.add(cache_key, initial_value)
     if added:


### PR DESCRIPTION
A custom reset callable can be passed into the decorator. When set, this reset callable will be called for every request made. The callable can return True/False. If True, the current counter will be reset to zero.

I personally use it to integrate with django-recaptcha like this:

``` python
def should_reset(request):
    if request.POST:
        form = ReCaptchaForm(request.POST)
        if form.is_valid():
            return True
    return False
```

With my view looking like this

``` python
@ratelimit(key='ip', rate='10/h', reset=should_reset)
def limited_view(request, **kwargs):
    was_limited = getattr(request, 'limited', False)
    if was_limited:
        return recaptcha_view(request)
```
