### PR TITLE
Will give the time-left for reset of counter in seconds along with count & limit

### DIFF
--- a/ratelimit/tests.py
+++ b/ratelimit/tests.py
@@ -47,7 +47,7 @@ class RatelimitTests(TestCase):
         cache.clear()
 
     def test_no_key(self):
-        @ratelimit()
+        @ratelimit(rate='1/m', block=True)
         def view(request):
             return True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal=1
+
+[flake8]
+ignore=E731


### PR DESCRIPTION
function added 
`get_usage_count` in  **utils.py**

this results in **dict**:

`{'count': count, 'limit':limit, 'time-left': time-left-for-next-cycle-in-seconds}`