### PR TITLE
Prevent warning message 'RemovedInDjango19Warning' in Django 1.8

### DIFF
--- a/ratelimit/middleware.py
+++ b/ratelimit/middleware.py
@@ -1,3 +1,4 @@
+from django import VERSION as django_version
 if django_version < (1, 8):
     from django.utils.importlib import import_module
 else:

--- a/ratelimit/middleware.py
+++ b/ratelimit/middleware.py
@@ -1,6 +1,6 @@
-try:
+if django_version < (1, 8):
     from django.utils.importlib import import_module
-except ImportError:
+else:
     from importlib import import_module
 
 from django.conf import settings


### PR DESCRIPTION
Using Django 1.8 we have a warning 
"RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9. from django.utils.importlib import import_module"

A try was append to prevent the error in Django 1.9 but the warning continue in 1.8.
Now it's working in all platforms.