### PR TITLE
Django 1.10 Middleware

### DIFF
--- a/ratelimit/middleware.py
+++ b/ratelimit/middleware.py
@@ -3,8 +3,12 @@ try:
 except ImportError:
     from importlib import import_module
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+
 from django.conf import settings
-from django.utils.deprecation import MiddlewareMixin
 
 from ratelimit.exceptions import Ratelimited
 

--- a/ratelimit/middleware.py
+++ b/ratelimit/middleware.py
@@ -4,11 +4,12 @@ except ImportError:
     from importlib import import_module
 
 from django.conf import settings
+from django.utils.deprecation import MiddlewareMixin
 
 from ratelimit.exceptions import Ratelimited
 
 
-class RatelimitMiddleware(object):
+class RatelimitMiddleware(MiddlewareMixin):
     def process_exception(self, request, exception):
         if not isinstance(exception, Ratelimited):
             return


### PR DESCRIPTION
Resolves #109 by making the middleware subclass from the Django deprecation MiddlewareMixin

https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-middleware