### PR TITLE
Update to work with requests from Django Rest Framework.

### DIFF
--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -4,6 +4,8 @@ from functools import wraps
 
 from django.http import HttpRequest
 
+from rest_framework.request import Request
+
 from ratelimit import ALL, UNSAFE
 from ratelimit.exceptions import Ratelimited
 from ratelimit.utils import is_ratelimited
@@ -17,9 +19,10 @@ def ratelimit(group=None, key=None, rate=None, method=ALL, block=False):
         @wraps(fn)
         def _wrapped(*args, **kw):
             # Work as a CBV method decorator.
-            if isinstance(args[0], HttpRequest):
+            if isinstance(args[0], HttpRequest) or isinstance(args[0], Request):
                 request = args[0]
             else:
+                print args
                 request = args[1]
             request.limited = getattr(request, 'limited', False)
             ratelimited = is_ratelimited(request=request, group=group, fn=fn,


### PR DESCRIPTION
When using the DRF decorator like @api_view, django passes an instance of rest_framework.request.Request and not an instance of HttpRequest, so I updated the if the statement to work with it.

```
@api_view(['POST'])
@permission_classes((IsAuthenticated,))
@ratelimit(key='user', rate='100/h')
def emailReceipts(request):
    pass
```