### PR TITLE
Test against Django 1.11 (and Python 3.6).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ env:
  - DJANGO_VERSION=1.8
  - DJANGO_VERSION=1.9
  - DJANGO_VERSION=1.10
+ - DJANGO_VERSION=1.11
 python:
  - "2.7"
  - "3.3"
  - "3.4"
  - "3.5"
+ - "3.6"
  - "pypy"
 install:
  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install -q python-memcached>=1.57; fi
@@ -24,3 +26,5 @@ matrix:
       env: DJANGO_VERSION=1.9
     - python: "3.3"
       env: DJANGO_VERSION=1.10
+    - python: "3.3"
+      env: DJANGO_VERSION=1.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
  - DJANGO_VERSION=1.9
  - DJANGO_VERSION=1.10
  - DJANGO_VERSION=1.11
+ - DJANGO_VERSION=2.0b1
 python:
  - "2.7"
  - "3.3"
@@ -28,3 +29,9 @@ matrix:
       env: DJANGO_VERSION=1.10
     - python: "3.3"
       env: DJANGO_VERSION=1.11
+    - python: "3.3"
+      env: DJANGO_VERSION=2.0b1
+    - python: "2.7"
+      env: DJANGO_VERSION=2.0b1
+    - python: "pypy"
+      env: DJANGO_VERSION=2.0b1

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0b1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,15 @@
 [tox]
 envlist =
-    py27-django{18,19,110},
-    py{33,34,35}-django{18,19,110}
+    py27-django{18,19,110,111},
+    py{33,34,35}-django{18,19,110,111},
+    py{36}-django{111}
 
 [testenv]
 deps =
     py{26,27}: python-memcached>=1.57
-    py{33,34}: python3-memcached>=1.51
+    py{33,34,35,36}: python3-memcached>=1.51
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<1.12
 commands = ./run.sh test

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     py27-django{18,19,110,111},
-    py{33,34,35}-django{18,19,110,111},
-    py{36}-django{111}
+    py{33,34,35}-django{18,19,110,111,20b1},
+    py{36}-django{111,20b1}
 
 [testenv]
 deps =
@@ -12,4 +12,5 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
+    django20b1: Django>=2.0b1,<2.1
 commands = ./run.sh test


### PR DESCRIPTION
See https://docs.djangoproject.com/en/1.11/faq/install/#what-python-version-can-i-use-with-django for a list of supported Pythons.

Closes https://github.com/jsocol/django-ratelimit/issues/126