### PR TITLE
Fail closed by default when the cache is down

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install -q python-memcached>=1.57; fi
  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install -q python3-memcached>=1.51; fi
  - if [[ $TRAVIS_PYTHON_VERSION == pypy ]]; then pip install -q python-memcached>=1.57; fi
- - pip install -q "Django>=${DJANGO_VERSION},<${DJANGO_VERSION}.99" flake8
+ - pip install -q "Django>=${DJANGO_VERSION},<${DJANGO_VERSION}.99" flake8 django-redis==4.8.0
 script:
  - ./run.sh test
  - ./run.sh flake8

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -41,3 +41,8 @@ The name of the cache (from the ``CACHES`` dict) to use. Defaults to
 The string import path to a view to use when a request is ratelimited, in
 conjunction with ``RatelimitMiddleware``, e.g. ``'myapp.views.ratelimited'``.
 Has no default - you must set this to use ``RatelimitMiddleware``.
+
+``RATELIMIT_FAIL_OPEN``
+------------------
+
+Whether to allow requests when the cache backend fails. Defaults to ``False``.

--- a/ratelimit/tests.py
+++ b/ratelimit/tests.py
@@ -426,6 +426,20 @@ class RatelimitTests(TestCase):
         assert not do_increment(req)
         assert req.limited is False
 
+    @override_settings(RATELIMIT_USE_CACHE='connection-errors-redis')
+    def test_is_ratelimited_cache_connection_error_with_increment_redis(self):
+        def get_key(group, request):
+            return 'test_is_ratelimited_key'
+
+        def do_increment(request):
+            return is_ratelimited(request, increment=True,
+                                  method=is_ratelimited.ALL, key=get_key,
+                                  rate='1/m', group='a')
+
+        req = rf.get('/')
+        assert do_increment(req)
+        assert req.limited is True
+
     @override_settings(RATELIMIT_USE_CACHE='instant-expiration')
     def test_cache_timeout(self):
         @ratelimit(key='ip', rate='1/m', block=True)

--- a/ratelimit/utils.py
+++ b/ratelimit/utils.py
@@ -126,7 +126,15 @@ def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
         return False
     usage = get_usage_count(request, group, fn, key, rate, method, increment)
 
-    limited = usage.get('count') > usage.get('limit')
+    fail_open = getattr(settings, 'RATELIMIT_FAIL_OPEN', False)
+
+    usage_count = usage.get('count')
+    if usage_count is None:
+        limited = not fail_open
+    else:
+        usage_limit = usage.get('limit')
+        limited = usage_count > usage_limit
+
     if increment:
         request.limited = old_limited or limited
     return limited

--- a/test_settings.py
+++ b/test_settings.py
@@ -15,6 +15,13 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
         'LOCATION': 'test-connection-errors',
     },
+    'connection-errors-redis': {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': 'test-connection-errors',
+        'OPTIONS': {
+            'IGNORE_EXCEPTIONS': True,
+        }
+    },
     'instant-expiration': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
         'LOCATION': 'test-instant-expiration',


### PR DESCRIPTION
When the cache is down operations may return None (Memcached, Redis with IGNORE_EXCEPTIONS=True). In these situations django-ratelimit crashes.