### PR TITLE
Fix warnings when building docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -8,7 +8,9 @@ Contributing
 Set Up
 ======
 
-Create a virtualenv_ and install Django with pip_::
+Create a virtualenv_ and install Django with pip_:
+
+.. code-block:: sh
 
     $ pip install Django
 
@@ -16,19 +18,25 @@ Create a virtualenv_ and install Django with pip_::
 Running the Tests
 =================
 
-Running the tests is as easy as::
+Running the tests is as easy as:
+
+.. code-block:: sh
 
     $ ./run.sh test
 
 You may also run the test on multiple versions of Django using tox.
 
-- First install tox::
+- First install tox:
 
-    $ pip install tox
+  .. code-block:: sh
 
-- Then run the tests with tox::
+      $ pip install tox
 
-    $ tox
+- Then run the tests with tox:
+
+  .. code-block:: sh
+
+      $ tox
 
 
 Code Standards

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -43,6 +43,6 @@ conjunction with ``RatelimitMiddleware``, e.g. ``'myapp.views.ratelimited'``.
 Has no default - you must set this to use ``RatelimitMiddleware``.
 
 ``RATELIMIT_FAIL_OPEN``
-------------------
+-----------------------
 
 Whether to allow requests when the cache backend fails. Defaults to ``False``.


### PR DESCRIPTION
* Fix `/Users/chainz/Documents/Projects/django-ratelimit/docs/settings.rst:46: WARNING: Title underline too short.`
* Fix repeated `WARNING: Could not lex literal_block as "python". Highlighting skipped.` in `contributing.rst` by using explicit shell code blocks
* Fix `WARNING: html_static_path entry '/Users/chainz/Documents/Projects/django-ratelimit/docs/_static' does not exist` by commenting out autogenerated `html_static_path`