### PR TITLE
Fix flake8 error

### DIFF
--- a/ratelimit/utils.py
+++ b/ratelimit/utils.py
@@ -57,7 +57,7 @@ def _method_match(request, method=ALL):
     return request.method in [m.upper() for m in method]
 
 
-rate_re = re.compile('([\d]+)/([\d]*)([smhd])?')
+rate_re = re.compile(r'([\d]+)/([\d]*)([smhd])?')
 
 
 def _split_rate(rate):


### PR DESCRIPTION
The tests have been failing and since they run on Travis cron every week, they email me every saturday, since I'm the last committer. Example: https://travis-ci.org/jsocol/django-ratelimit/jobs/447157626

The error is:

```
$ ./run.sh flake8
ratelimit/utils.py:60:4: W605 invalid escape sequence '\d'
ratelimit/utils.py:60:12: W605 invalid escape sequence '\d'
```

The fix is simple, raw string mode should be used for the regex.