### PR TITLE
Drop Python 3.3 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
  - DJANGO_VERSION=2.0b1
 python:
  - "2.7"
- - "3.3"
  - "3.4"
  - "3.5"
  - "3.6"
@@ -23,14 +22,6 @@ script:
  - ./run.sh flake8
 matrix:
   exclude:
-    - python: "3.3"
-      env: DJANGO_VERSION=1.9
-    - python: "3.3"
-      env: DJANGO_VERSION=1.10
-    - python: "3.3"
-      env: DJANGO_VERSION=1.11
-    - python: "3.3"
-      env: DJANGO_VERSION=2.0b1
     - python: "2.7"
       env: DJANGO_VERSION=2.0b1
     - python: "pypy"

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     url='https://github.com/jsocol/django-ratelimit',
     license='Apache Software License',
     packages=find_packages(exclude=['test_settings']),
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     include_package_data=True,
     package_data={'': ['README.rst']},
     classifiers=[
@@ -31,7 +32,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
It's failing on tests for flake8 which dies with:

```
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/flake8/plugins/manager.py", line 5, in <module>
    import pkg_resources
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/pkg_resources/__init__.py", line 90, in <module>
    raise RuntimeError("Python 3.4 or later is required")
RuntimeError: Python 3.4 or later is required
```

Also most Django versions we test on don't support it, and it's EOL.