### PR TITLE
Avoid RemovedInDjango20Warning in Django 1.10,1.11

### DIFF
--- a/ratelimit/utils.py
+++ b/ratelimit/utils.py
@@ -187,8 +187,12 @@ is_ratelimited.UNSAFE = UNSAFE
 
 
 def is_authenticated(user):
-    # is_authenticated was a method in Django < 1.10
-    if callable(user.is_authenticated):
+    if getattr(user.is_authenticated, 'do_not_call_in_templates', False):
+        # is_authenticated is a CallableBool in Django 1.10, 1.11
+        # but calling raises RemovedInDjango20Warning
+        return user.is_authenticated
+    elif callable(user.is_authenticated):
+        # is_authenticated was a method in Django < 1.10
         return user.is_authenticated()
     else:
         return user.is_authenticated


### PR DESCRIPTION
In Django 1.10 and 1.11, ``user.is_authenticated`` is a [CallableBool](https://github.com/django/django/blob/0ecc4f8d497679979f48ff18754494e8387a494d/django/utils/deprecation.py#L99-L105), which is callable but raises a ``RemovedInDjango20Warning``, which makes it difficult to see the other code that needs to change for our upgrade.

Use the template API attribute [do_not_call_in_templates](https://github.com/django/django/blob/53e85705221dcc5302393aac40f4fa606e2097d3/docs/ref/templates/api.txt#L340-L345) to identify the [CallableBool](https://github.com/django/django/blob/0ecc4f8d497679979f48ff18754494e8387a494d/django/utils/deprecation.py#L91), to treat it as an attribute rather than a method. The paths for < 1.10 and >= 2.0 continue to work.

I also considered an ``isinstance(user.is_authenticated, CallableBool)`` test, but this class has been removed from Django 2.0, and the conditional import seemed uglier than this version.