### PR TITLE
Update text matrix for Django 2.0, 2.1, master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ env:
  - DJANGO_VERSION=1.9
  - DJANGO_VERSION=1.10
  - DJANGO_VERSION=1.11
- - DJANGO_VERSION=2.0b1
+ - DJANGO_VERSION=2.0
+ - DJANGO_VERSION=2.1
+ - DJANGO_VERSION=master
 python:
  - "2.7"
  - "3.4"
@@ -16,13 +18,40 @@ install:
  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install -q python-memcached>=1.57; fi
  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install -q python3-memcached>=1.51; fi
  - if [[ $TRAVIS_PYTHON_VERSION == pypy ]]; then pip install -q python-memcached>=1.57; fi
- - pip install -q "Django>=${DJANGO_VERSION},<${DJANGO_VERSION}.99" flake8 django-redis==4.8.0
+ - if [[ $DJANGO_VERSION != master ]]; then pip install -q "Django>=${DJANGO_VERSION},<${DJANGO_VERSION}.99"; fi
+ - if [[ $DJANGO_VERSION == master ]]; then pip install https://github.com/django/django/archive/master.tar.gz; fi
+ - if [[ $DJANGO_VERSION == 1* ]]; then pip install django-redis==4.8.0; fi
+ - if [[ $DJANGO_VERSION != 1* ]]; then pip install django-redis==4.9.0; fi
+ - pip install flake8
 script:
  - ./run.sh test
  - ./run.sh flake8
 matrix:
   exclude:
     - python: "2.7"
-      env: DJANGO_VERSION=2.0b1
+      env: DJANGO_VERSION=2.0
+    - python: "2.7"
+      env: DJANGO_VERSION=2.1
+    - python: "2.7"
+      env: DJANGO_VERSION=master
+    - python: "3.4"
+      env: DJANGO_VERSION=2.1
+    - python: "3.4"
+      env: DJANGO_VERSION=master
+    - python: "3.6"
+      env: DJANGO_VERSION=1.8
+    - python: "3.6"
+      env: DJANGO_VERSION=1.9
+    - python: "3.6"
+      env: DJANGO_VERSION=1.10
     - python: "pypy"
-      env: DJANGO_VERSION=2.0b1
+      env: DJANGO_VERSION=2.0
+    - python: "pypy"
+      env: DJANGO_VERSION=2.1
+    - python: "pypy"
+      env: DJANGO_VERSION=master
+  allow_failures:
+    - python: "3.5"
+      env: DJANGO_VERSION=master
+    - python: "3.6"
+      env: DJANGO_VERSION=master

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,27 @@
 [tox]
 envlist =
     py27-django{18,19,110,111},
-    py{33,34,35}-django{18,19,110,111,20},
-    py{36}-django{111,20}
+    py34-django{18,19,110,111,20},
+    py35-django{18,19,110,111,20,21,master},
+    py36-django{111,20,21,master},
+    py37-django{20,21,master},
+    pypy-django{18,19,110,111}
 
 [testenv]
 deps =
-    py{26,27}: python-memcached>=1.57
-    py{33,34,35,36}: python3-memcached>=1.51
+    py{27,py}: python-memcached>=1.57
+    py{34,35,36,37}: python3-memcached>=1.51
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
-    django20: Django>=2.0b1,<2.1
-commands = ./run.sh test
+    django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
+    djangomaster: https://github.com/django/django/archive/master.tar.gz
+    django{18,19,110,111}: django-redis==4.8.0
+    django{20,21,master}: django-redis==4.9.0
+    flake8
+
+commands =
+    ./run.sh test
+    ./run.sh flake8


### PR DESCRIPTION
* Add non-beta release of Django 2.0
* Add Django 2.1, and a build of the master branch that is allowed to fail
* Update the tox matrix for the supported Python versions. Tox fails for me for some builds, but they all fail in current master, so progress?