### PR TITLE
Remove passwords from recommended cache keys

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -116,16 +116,16 @@ Protecting against the single IP address cases is easy::
     def login_view(request):
         pass
 
-Also limiting by username and password provides better protection::
+Also limiting by username provides better protection::
 
     @ratelimit(key='ip')
     @ratelimit(key='post:username')
-    @ratelimit(key='post:password')
     def login_view(request):
         pass
 
-Key values are never stored in a raw form, even as cache keys, but
-they are constructed with a fast hash function.
+**Using passwords as key values is not recommended.** Key values are
+never stored in a raw form, even as cache keys, but they are constructed
+with a fast hash function.
 
 
 Denial of Service

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -94,7 +94,7 @@ Examples
         return HttpResponse()
 
     @ratelimit(key='post:username', rate='5/m')
-    @ratelimit(key='post:password', rate='5/m')
+    @ratelimit(key='post:tenant', rate='5/m')
     def login(request):
         # Use multiple keys by stacking decorators.
         return HttpResponse()


### PR DESCRIPTION
Fix #125. Remove passwords from examples and recommended cache keys and
emphasize note in security section about fast hashes.

[skip ci]