### PR TITLE
Do not mutate request in is_ratelimited

### DIFF
--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -14,10 +14,11 @@ def ratelimit(group=None, key=None, rate=None, method=ALL, block=False):
     def decorator(fn):
         @wraps(fn)
         def _wrapped(request, *args, **kw):
-            request.limited = getattr(request, 'limited', False)
+            old_limited = getattr(request, 'limited', False)
             ratelimited = is_ratelimited(request=request, group=group, fn=fn,
                                          key=key, rate=rate, method=method,
                                          increment=True)
+            request.limited = ratelimited or old_limited
             if ratelimited and block:
                 raise Ratelimited()
             return fn(request, *args, **kw)

--- a/ratelimit/utils.py
+++ b/ratelimit/utils.py
@@ -104,7 +104,6 @@ def _make_cache_key(group, rate, value, methods):
 def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
                    method=ALL, increment=False):
     if not getattr(settings, 'RATELIMIT_ENABLE', True):
-        request.limited = False
         return False
 
     if not _method_match(request, method):
@@ -130,13 +129,10 @@ def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
         parts.append(fn.__qualname__)
         group = '.'.join(parts)
 
-    old_limited = getattr(request, 'limited', False)
-
     if callable(rate):
         rate = rate(group, request)
 
     if rate is None:
-        request.limited = old_limited
         return False
     usage = get_usage_count(request, group, fn, key, rate, method, increment)
 
@@ -149,8 +145,6 @@ def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
         usage_limit = usage.get('limit')
         limited = usage_count > usage_limit
 
-    if increment:
-        request.limited = old_limited or limited
     return limited
 
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -23,9 +23,8 @@ CACHES = {
         }
     },
     'instant-expiration': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
         'LOCATION': 'test-instant-expiration',
-        'TIMEOUT': 0,
     },
 }
 


### PR DESCRIPTION
A number of tests were either wrong (😱) or could have easily hidden issues because they were reusing the same request object. This fixes those tests so that they don't reuse requests but instead generate new ones.

Tweak how mutation happens in the decorator but remove all request mutation from is_ratelimited. Tests were already updated to no longer expect the mutation behavior.