### PR TITLE
Refactor utils

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,11 +13,20 @@ Breaking changes:
 - @ratelimit no longer directly supports class methods, use
   @method_decorator
 - Drop RatelimitMixin in favor of @method_decorator
+- Moved is_ratelimited to ratelimit.core from ratelimit.utils
+- Moved ratelimit.utils.get_usage_count to ratelimit.core.get_usage
+
+Additions:
+----------
+
+- Made ratelimit.core.get_usage a documented, public method.
 
 Minor changes:
 --------------
 
 - Update RatelimitMiddleware to modern style (#168)
+- Refactor is_ratelimited and get_usage so is_ratelimited is a thinner
+  wrapper
 
 v2.0.0
 ======

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -17,6 +17,8 @@ Quickly:
 - ``@ratelimit`` no longer works directly on class methods, add
   ``@method_decorator``.
 - ``RatelimitMixin`` is gone, migrate to ``@method_decorator``.
+- Moved ``is_ratelimted`` method from ``ratelimit.utils`` to
+  ``ratelimit.core``.
 
 ``@ratelimit`` decorator on class methods
 -----------------------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -201,7 +201,7 @@ Class-Based View Mixin
 ======================
 
 .. versionadded:: 0.4
-.. versionremoved:: 3.0
+.. deprecated:: 3.0
 
 The ``RatelimitMixin`` was never as powerful or flexible as the
 ``@ratelimit`` decorator, and given that it is possible to use the
@@ -211,21 +211,23 @@ deprecated.
 
 .. _usage-helper:
 
-Helper Function
-===============
+Core Methods
+============
 
-.. versionchanged:: 3.0
+.. versionadded:: 3.0
 
-In some cases the decorator is not flexible enough. If this is an
-issue you use the ``is_ratelimited`` helper function. It's similar to
-the decorator.
+In some cases the decorator is not flexible enough to, e.g.,
+conditionally apply rate limits. In these cases, you can access the core
+functionality in ``ratelimit.core``. The two major methods are
+``get_usage`` and ``is_ratelimited``.
+
 
 .. code-block:: python
 
-    from ratelimit.utils import is_ratelimited
+    from ratelimit.core import get_usage, is_ratelimited
 
-
-.. py:function:: is_ratelimited(request, group=None, key=, rate=None, method=ALL, increment=False)
+.. py:function:: get_usage(request, group=None, fn=None, key=None, \
+                           rate=None, method=ALL, increment=False)
 
    :arg request:
        *None* The HTTPRequest object.
@@ -233,6 +235,10 @@ the decorator.
    :arg group:
        *None* A group of rate limits to count together. Defaults to the
        dotted name of the view.
+
+   :arg fn:
+       *None* A view function which can be used to calculate the group
+       as if it was decorated by :ref:`@ratelimit <usage-decorator>`.
 
    :arg key:
        What key to use, see :ref:`Keys <keys-chapter>`.
@@ -254,6 +260,55 @@ the decorator.
 
    :arg increment:
        *False* Whether to increment the count or just check.
+
+   :returns dict or None:
+       Either returns None, indicating that ratelimiting was not active
+       for this request (for some reason) or returns a dict including
+       the current count, limit, time left in the window, and whether
+       this request should be limited.
+
+.. py:function:: is_ratelimited(request, group=None, fn=None, \
+                                key=None, rate=None, method=ALL, \
+                                increment=False)
+
+   :arg request:
+       *None* The HTTPRequest object.
+
+   :arg group:
+       *None* A group of rate limits to count together. Defaults to the
+       dotted name of the view.
+
+   :arg fn:
+       *None* A view function which can be used to calculate the group
+       as if it was decorated by :ref:`@ratelimit <usage-decorator>`.
+
+   :arg key:
+       What key to use, see :ref:`Keys <keys-chapter>`.
+
+   :arg rate:
+       *'5/m'* The number of requests per unit time allowed. Valid
+       units are:
+
+       * ``s`` - seconds
+       * ``m`` - minutes
+       * ``h`` - hours
+       * ``d`` - days
+
+       Also accepts callables. See :ref:`Rates <rates-chapter>`.
+
+   :arg method:
+       *ALL* Which HTTP method(s) to rate-limit. May be a string, a
+       list/tuple, or ``None`` for all methods.
+
+   :arg increment:
+       *False* Whether to increment the count or just check.
+
+   :returns bool:
+       Whether this request should be limited or not.
+
+
+``is_ratelimited`` is a thin wrapper around ``get_usage`` that is
+maintained for compatibility. It provides strictly less information.
 
 
 .. _usage-exception:

--- a/ratelimit/core.py
+++ b/ratelimit/core.py
@@ -12,7 +12,7 @@ from django.utils.module_loading import import_string
 from ratelimit import ALL, UNSAFE
 
 
-__all__ = ['is_ratelimited']
+__all__ = ['is_ratelimited', 'get_usage']
 
 _PERIODS = {
     's': 1,
@@ -206,3 +206,5 @@ def get_usage(request, group=None, fn=None, key=None, rate=None, method=ALL,
 
 is_ratelimited.ALL = ALL
 is_ratelimited.UNSAFE = UNSAFE
+get_usage.ALL = ALL
+get_usage.UNSAFE = UNSAFE

--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -4,7 +4,7 @@ from functools import wraps
 
 from ratelimit import ALL, UNSAFE
 from ratelimit.exceptions import Ratelimited
-from ratelimit.utils import is_ratelimited
+from ratelimit.core import is_ratelimited
 
 
 __all__ = ['ratelimit']

--- a/ratelimit/tests.py
+++ b/ratelimit/tests.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from django.core.cache import cache, InvalidCacheBackendError
 from django.core.exceptions import ImproperlyConfigured
 from django.test import RequestFactory, TestCase
@@ -7,7 +9,7 @@ from django.views.generic import View
 
 from ratelimit.decorators import ratelimit
 from ratelimit.exceptions import Ratelimited
-from ratelimit.utils import is_ratelimited, _split_rate
+from ratelimit.core import get_usage, is_ratelimited, _split_rate
 
 
 rf = RequestFactory()
@@ -285,34 +287,65 @@ class RatelimitTests(TestCase):
         assert not get_post(rf.get('/'))
         assert post_get(rf.get('/'))
 
+
+class FunctionsTests(TestCase):
+    def setUp(self):
+        cache.clear()
+
     def test_is_ratelimited(self):
-        def get_key(group, request):
-            return 'test_is_ratelimited_key'
-
-        def not_increment(request):
-            return is_ratelimited(request, increment=False,
-                                  method=is_ratelimited.ALL, key=get_key,
-                                  rate='1/m', group='a')
-
-        def do_increment(request):
-            return is_ratelimited(request, increment=True,
-                                  method=is_ratelimited.ALL, key=get_key,
-                                  rate='1/m', group='a')
+        not_increment = partial(is_ratelimited, increment=False, rate='1/m',
+                                method=is_ratelimited.ALL, key='ip', group='a')
 
         # Does not increment. Count still 0. Does not rate limit
         # because 0 < 1.
         assert not not_increment(rf.get('/'))
 
-        # Increments. Does not rate limit because 0 < 1. Count now 1.
-        assert not do_increment(rf.get('/'))
-
         # Does not increment. Count still 1. Not limited because 1 > 1
         # is false.
         assert not not_increment(rf.get('/'))
 
+    def test_is_ratelimited_increment(self):
+        do_increment = partial(is_ratelimited, increment=True, rate='1/m',
+                               method=is_ratelimited.ALL, key='ip', group='a')
+
+        # Increments. Does not rate limit because 0 < 1. Count now 1.
+        assert not do_increment(rf.get('/'))
+
         # Count = 2, 2 > 1.
         assert do_increment(rf.get('/'))
-        assert not_increment(rf.get('/'))
+
+    def test_get_usage(self):
+        _get_usage = partial(get_usage, method=get_usage.ALL, key='ip',
+                             rate='1/m', group='a')
+        usage = _get_usage(rf.get('/'))
+
+        self.assertEqual(usage['count'], 0)
+        self.assertEqual(usage['limit'], 1)
+        self.assertLessEqual(usage['time_left'], 60)
+        self.assertFalse(usage['should_limit'])
+
+    def test_get_usage_increment(self):
+        _get_usage = partial(get_usage, method=get_usage.ALL, key='ip',
+                             rate='1/m', group='a', increment=True)
+        _get_usage(rf.get('/'))
+        usage = _get_usage(rf.get('/'))
+
+        self.assertEqual(usage['count'], 2)
+        self.assertEqual(usage['limit'], 1)
+        self.assertLessEqual(usage['time_left'], 60)
+        self.assertTrue(usage['should_limit'])
+
+    def test_not_increment_after_increment(self):
+        _get_usage = partial(get_usage, method=get_usage.ALL, key='ip',
+                             rate='1/m', group='a')
+        _get_usage(rf.get('/'), increment=True)
+        _get_usage(rf.get('/'), increment=True)
+        usage = _get_usage(rf.get('/'))
+
+        self.assertEqual(usage['count'], 2)
+        self.assertEqual(usage['limit'], 1)
+        self.assertLessEqual(usage['time_left'], 60)
+        self.assertTrue(usage['should_limit'])
 
 
 class RatelimitCBVTests(TestCase):


### PR DESCRIPTION

Refactor (and fix) is_ratelimited and get_usage

get_usage(_count) is a more powerful method, so add to its return value
slightly and move the important logic of is_ratelimited inside it so it
can be called directly. Update is_ratelimited to be a thin wrapper
around get_usage.

Cleaned up some tests and exposed some issues relating to refactor, so
fixed those.

"utils" is a terrible name for a module that contains the core logic of
the library. Renamed ratelimit/utils.py to ratelimit/core.py and updated
imports. Restructured some tests and added tests for public get_usage
method.