### PR TITLE
Throw if get_usage is called without enough info

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -310,6 +310,12 @@ functionality in ``ratelimit.core``. The two major methods are
 ``is_ratelimited`` is a thin wrapper around ``get_usage`` that is
 maintained for compatibility. It provides strictly less information.
 
+.. warning::
+    
+    ``get_usage`` and ``is_ratelimited`` require either ``group=`` or
+    ``fn=`` to be passed, or they cannot determine the rate limiting
+    state and will throw.
+
 
 .. _usage-exception:
 

--- a/ratelimit/core.py
+++ b/ratelimit/core.py
@@ -111,6 +111,10 @@ def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
 
 def get_usage(request, group=None, fn=None, key=None, rate=None, method=ALL,
               increment=False):
+    if group is None and fn is None:
+        raise ImproperlyConfigured('get_usage must be called with either '
+                                   '`group` or `fn` arguments')
+
     if not getattr(settings, 'RATELIMIT_ENABLE', True):
         return None
 

--- a/ratelimit/tests.py
+++ b/ratelimit/tests.py
@@ -347,6 +347,10 @@ class FunctionsTests(TestCase):
         self.assertLessEqual(usage['time_left'], 60)
         self.assertTrue(usage['should_limit'])
 
+    def test_get_usage_called_without_group_or_fn(self):
+        with self.assertRaises(ImproperlyConfigured):
+            get_usage(rf.get('/'), key='ip')
+
 
 class RatelimitCBVTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
get_usage (and thus is_ratelimited) either a group or an fn argument. If
neither is passed, throw ImproperlyConfigured, which is what we've used
for similar call site errors.

Fixes #53.