### PR TITLE
Update middleware examples to new-style

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -59,15 +59,17 @@ Middleware
 Writing a small middleware class to set ``REMOTE_ADDR`` to the actual
 client IP address is generally simple::
 
-    class ReverseProxy(object):
-        def process_request(self, request):
+    def reverse_proxy(get_response):
+        def process_request(request):
             request.META['REMOTE_ADDR'] = # [...]
+            return get_response(request)
+        return process_request
 
 where ``# [...]`` depends on your environment. This middleware should be
 close to the top of the list::
 
-    MIDDLEWARE_CLASSES = (
-        'path.to.ReverseProxy',
+    MIDDLEWARE = (
+        'path.to.reverse_proxy',
         # ...
     )
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -347,7 +347,7 @@ There is optional middleware to use a custom view to handle ``Ratelimited``
 exceptions.
 
 To use it, add ``ratelimit.middleware.RatelimitMiddleware`` to your
-``MIDDLEWARE_CLASSES`` (toward the bottom of the list) and set
+``MIDDLEWARE`` (toward the bottom of the list) and set
 ``RATELIMIT_VIEW`` to the full path of a view you want to use.
 
 The view specified in ``RATELIMIT_VIEW`` will get two arguments, the


### PR DESCRIPTION
Updates the middleware example in the security chapter to new (>1.10)
style, and tweaks usage docs mentioning MIDDLEWARE_CLASSES setting.

Fixes #124.

[ci skip] docs-only