### PR TITLE
Clarify 0 and None rates

### DIFF
--- a/docs/rates.rst
+++ b/docs/rates.rst
@@ -20,6 +20,14 @@ and ``u`` is a unit from this list:
 
 (For example, you can read ``5/s`` as "five per second.")
 
+.. note::
+
+    Setting a rate of 0 per any unit of time will disallow requests,
+    e.g.  ``0/s`` will prevent any requests to the endpoint.
+
+Rates may also be set to ``None``, which indicates "there is no limit."
+Usage will not be tracked.
+
 You may also specify a number of units, i.e.: ``X/Yu`` where ``Y`` is a
 number of units. If ``u`` is omitted, it is presumed to be seconds. So,
 the following are equivalent, and all mean "one hundred requests per

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -33,7 +33,9 @@ Import::
         * ``h`` - hours
         * ``d`` - days
 
-        Also accepts callables. See :ref:`Rates <rates-chapter>`.
+        Also accepts callables. See :ref:`Rates <rates-chapter>`. A rate
+        of ``0/s`` disallows all requests. A rate of ``None`` means "no
+        limit" and will allow all requests.
 
    :arg method:
         *ALL* Which HTTP method(s) to rate-limit. May be a string, a


### PR DESCRIPTION
Make it more obvious, not buried at the bottom of a long section, what
happens when rates are set to 0/u or None.

Fixes #122. [ci skip] docs-only