### PR TITLE
Add IP masking (closes #175)

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -46,3 +46,14 @@ Has no default - you must set this to use ``RatelimitMiddleware``.
 -----------------------
 
 Whether to allow requests when the cache backend fails. Defaults to ``False``.
+
+``RATELIMIT_IPV4_MASK``
+-----------------------
+
+IPv4 mask for IP-based rate limit. Defaults to ``32`` (which is no masking)
+
+``RATELIMIT_IPV6_MASK``
+-----------------------
+
+IPv6 mask for IP-based rate limit. Defaults to ``64`` (which mask the last 64 bits).
+Typical end site IPv6 assignment are from /48 to /64.

--- a/ratelimit/core.py
+++ b/ratelimit/core.py
@@ -25,6 +25,7 @@ _PERIODS = {
 # Extend the expiration time by a few seconds to avoid misses.
 EXPIRATION_FUDGE = 5
 
+
 def ip_mask(ip):
     if ':' in ip:
         # IPv6
@@ -32,11 +33,11 @@ def ip_mask(ip):
     else:
         # IPv4
         mask = getattr(settings, 'RATELIMIT_IPV4_MASK', 32)
-    
+
     network = ipaddress.ip_network((ip, mask), strict=False)
 
     return str(network.network_address)
-    
+
 
 def user_or_ip(request):
     if request.user.is_authenticated:

--- a/ratelimit/core.py
+++ b/ratelimit/core.py
@@ -34,7 +34,7 @@ def ip_mask(ip):
         # IPv4
         mask = getattr(settings, 'RATELIMIT_IPV4_MASK', 32)
 
-    network = ipaddress.ip_network((ip, mask), strict=False)
+    network = ipaddress.ip_network('{}/{}'.format(ip, mask), strict=False)
 
     return str(network.network_address)
 

--- a/ratelimit/tests.py
+++ b/ratelimit/tests.py
@@ -287,6 +287,74 @@ class RatelimitTests(TestCase):
         assert not get_post(rf.get('/'))
         assert post_get(rf.get('/'))
 
+    def test_ratelimit_full_mask_v4(self):
+        @ratelimit(rate='1/m', key='ip')
+        def view(request):
+            return request.limited
+
+        with self.settings(RATELIMIT_IPV4_MASK=32):
+            req = rf.get('/')
+            req.META['REMOTE_ADDR'] = '10.1.1.1'
+            assert not view(req)
+            assert view(req)
+
+            req = rf.get('/')
+            req.META['REMOTE_ADDR'] = '10.1.1.2'
+            assert not view(req)
+    
+    def test_ratelimit_full_mask_v6(self):
+        @ratelimit(rate='1/m', key='ip')
+        def view(request):
+            return request.limited
+
+        with self.settings(RATELIMIT_IPV6_MASK=128):
+            req = rf.get('/')
+            req.META['REMOTE_ADDR'] = '2001:db8::1000'
+            assert not view(req)
+            assert view(req)
+
+            req = rf.get('/')
+            req.META['REMOTE_ADDR'] = '2001:db8::1001'
+            assert not view(req)
+    
+    def test_ratelimit_mask_v4(self):
+        @ratelimit(rate='1/m', key='ip')
+        def view(request):
+            return request.limited
+
+        with self.settings(RATELIMIT_IPV4_MASK=16):
+            req = rf.get('/')
+            req.META['REMOTE_ADDR'] = '10.1.1.1'
+            assert not view(req)
+            assert view(req)
+
+            req = rf.get('/')
+            req.META['REMOTE_ADDR'] = '10.1.0.1'
+            assert view(req)
+
+            req = rf.get('/')
+            req.META['REMOTE_ADDR'] = '192.168.1.1'
+            assert not view(req)
+    
+    def test_ratelimit_mask_v6(self):
+        @ratelimit(rate='1/m', key='ip')
+        def view(request):
+            return request.limited
+
+        with self.settings(RATELIMIT_IPV6_MASK=64):
+            req = rf.get('/')
+            req.META['REMOTE_ADDR'] = '2001:db8::1000'
+            assert not view(req)
+            assert view(req)
+
+            req = rf.get('/')
+            req.META['REMOTE_ADDR'] = '2001:db8::1001'
+            assert view(req)
+
+            req = rf.get('/')
+            req.META['REMOTE_ADDR'] = '2001:db9::1000'
+            assert not view(req)
+
 
 class FunctionsTests(TestCase):
     def setUp(self):
@@ -313,15 +381,6 @@ class FunctionsTests(TestCase):
 
         # Count = 2, 2 > 1.
         assert do_increment(rf.get('/'))
-
-    def test_ip_mask(self):
-        with self.settings(RATELIMIT_IPV4_MASK=32, RATELIMIT_IPV6_MASK=128):
-            self.assertEqual(ip_mask('10.1.1.1'), '10.1.1.1')
-            self.assertEqual(ip_mask('2001:db8::1000'), '2001:db8::1000')
-
-        with self.settings(RATELIMIT_IPV4_MASK=16, RATELIMIT_IPV6_MASK=64):
-            self.assertEqual(ip_mask('10.1.1.1'), '10.1.0.0')
-            self.assertEqual(ip_mask('2001:db8::1000'), '2001:db8::')
 
     def test_get_usage(self):
         _get_usage = partial(get_usage, method=get_usage.ALL, key='ip',

--- a/ratelimit/tests.py
+++ b/ratelimit/tests.py
@@ -9,7 +9,7 @@ from django.views.generic import View
 
 from ratelimit.decorators import ratelimit
 from ratelimit.exceptions import Ratelimited
-from ratelimit.core import get_usage, is_ratelimited, _split_rate, ip_mask
+from ratelimit.core import get_usage, is_ratelimited, _split_rate
 
 
 rf = RequestFactory()
@@ -301,7 +301,7 @@ class RatelimitTests(TestCase):
             req = rf.get('/')
             req.META['REMOTE_ADDR'] = '10.1.1.2'
             assert not view(req)
-    
+
     def test_ratelimit_full_mask_v6(self):
         @ratelimit(rate='1/m', key='ip')
         def view(request):
@@ -316,7 +316,7 @@ class RatelimitTests(TestCase):
             req = rf.get('/')
             req.META['REMOTE_ADDR'] = '2001:db8::1001'
             assert not view(req)
-    
+
     def test_ratelimit_mask_v4(self):
         @ratelimit(rate='1/m', key='ip')
         def view(request):
@@ -335,7 +335,7 @@ class RatelimitTests(TestCase):
             req = rf.get('/')
             req.META['REMOTE_ADDR'] = '192.168.1.1'
             assert not view(req)
-    
+
     def test_ratelimit_mask_v6(self):
         @ratelimit(rate='1/m', key='ip')
         def view(request):


### PR DESCRIPTION
This PR adds #175 . I was intending to work on this PR since I submitted the issue, but couldn't get a free time until now.

This has a breaking change: IPv6 address default mask is now /64 (from previously never masked, or equivalent to /128). I believe providing a secure default is more important, and /64 is the smallest prefix allocation site that it shouldn't affect anything except maybe intranet-based deployment.

The prefix size can be configured with `RATELIMIT_IPV4_MASK` and `RATELIMIT_IPV6_MASK` configuration.