### PR TITLE
Fix rate as dotted path to callable

### DIFF
--- a/docs/rates.rst
+++ b/docs/rates.rst
@@ -46,7 +46,7 @@ Callables
 .. versionadded:: 0.5
 
 Rates can also be callables (or dotted paths to callables, which are
-assumed if there is no ``/`` in the value).
+assumed if there is a ``.`` in the value).
 
 Callables receive two values, the :ref:`group <usage-chapter>` and the
 ``request`` object. They should return a simple rate string, or a tuple

--- a/ratelimit/core.py
+++ b/ratelimit/core.py
@@ -157,9 +157,15 @@ def get_usage(request, group=None, fn=None, key=None, rate=None, method=ALL,
 
     if callable(rate):
         rate = rate(group, request)
+    elif isinstance(rate, str) and '.' in rate:
+        ratefn = import_string(rate)
+        rate = ratefn(group, request)
+
     if rate is None:
         return None
     limit, period = _split_rate(rate)
+    if period <= 0:
+        raise ImproperlyConfigured('Ratelimit period must be greater than 0')
 
     if not key:
         raise ImproperlyConfigured('Ratelimit key must be specified')


### PR DESCRIPTION
The rate= keyword argument did not actually support the documented
behavior of allowing a dotted path to a callable. This implements that
behavior and aligns the implementation with the similar functionality
for callable keys.

Fixes #204