### PR TITLE
Add RATELIMIT_IP_HEADER to avoid hardcoded REMOTE_ADDR

### DIFF
--- a/ratelimit/core.py
+++ b/ratelimit/core.py
@@ -42,11 +42,11 @@ def ip_mask(ip):
 def user_or_ip(request):
     if request.user.is_authenticated:
         return str(request.user.pk)
-    return ip_mask(request.META['REMOTE_ADDR'])
+    return ip_mask(request.META[getattr(settings, 'RATELIMIT_IP_HEADER', 'REMOTE_ADDR')])
 
 
 _SIMPLE_KEYS = {
-    'ip': lambda r: ip_mask(r.META['REMOTE_ADDR']),
+    'ip': lambda r: ip_mask(r.META[getattr(settings, 'RATELIMIT_IP_HEADER', 'REMOTE_ADDR')]),
     'user': lambda r: str(r.user.pk),
     'user_or_ip': user_or_ip,
 }


### PR DESCRIPTION
I use Django axes which incorporates Django ipware. I also use nginx, so having a middleware for rate limit added too much complexity for me. I was wondering if you can add some kind of setting like this PR that'll access some setting which will grab the IP by the specified header. It'D be even better if it were a callable, but for now it's just a setting variable for one thing. (If it were a callable I would pass the request object as an arg). 

Also, should this become a module level variable instead?