### PR TITLE
Add informative parameters to 'RateLimited' Exception

### DIFF
--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -20,7 +20,7 @@ def ratelimit(group=None, key=None, rate=None, method=ALL, block=False):
                                          increment=True)
             request.limited = ratelimited or old_limited
             if ratelimited and block:
-                raise Ratelimited()
+                raise Ratelimited(group=group, key=key, rate=rate)
             return fn(request, *args, **kw)
         return _wrapped
     return decorator

--- a/ratelimit/exceptions.py
+++ b/ratelimit/exceptions.py
@@ -2,4 +2,9 @@ from django.core.exceptions import PermissionDenied
 
 
 class Ratelimited(PermissionDenied):
-    pass
+
+    def __init__(self, group, key, rate):
+        super(Ratelimited, self).__init__()
+        self.group = group
+        self.key = key
+        self.rate = rate


### PR DESCRIPTION
Add 'key', 'group' and 'rate' details to 'RateLimited' Exception, in order to allow proper differentiation and documentation in case of multiple rate limit decorators on the same Django view.