### PR TITLE
Add RATELIMIT_IP_META_KEY setting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,14 @@
 Change Log
 ==========
 
+UNRELEASED
+==========
+
+Minor changes:
+--------------
+
+- Factor up _get_ip() logic into a single place
+
 3.0.1
 =====
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,10 +5,15 @@ Change Log
 UNRELEASED
 ==========
 
+Additions:
+----------
+
+- Add RATELIMIT_IP_META_KEY setting (#218)
+
 Minor changes:
 --------------
 
-- Factor up _get_ip() logic into a single place
+- Factor up _get_ip() logic into a single place (#218)
 
 3.0.1
 =====

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -47,6 +47,30 @@ Has no default - you must set this to use ``RatelimitMiddleware``.
 
 Whether to allow requests when the cache backend fails. Defaults to ``False``.
 
+``RATELIMIT_IP_META_KEY``
+-------------------------
+
+Set the source of the client IP address in the request.META object. Defaults to
+``None``.
+
+There are several potential values:
+
+``None``
+  Use ``request.META['REMOTE_ADDR']`` as the source of the client IP address.
+
+A callable object
+  If set to a callable, the callable will be passed the full ``request``
+  object. The callable must return the client IP address. For example:
+  ``RATELIMIT_IP_META_KEY = lambda r: r.META['HTTP_X_CLIENT_IP']``
+
+A dotted path to a callable
+  Any string containing a ``.`` will be treated as a dotted path to a callable,
+  which will be imported and called on the ``request`` object, as above.
+
+Any other string
+  Any other string will be treated as a key for the ``request.META`` object,
+  e.g. ``RATELIMIT_IP_META_KEY = 'HTTP_X_REAL_IP'``
+
 ``RATELIMIT_IPV4_MASK``
 -----------------------
 

--- a/ratelimit/core.py
+++ b/ratelimit/core.py
@@ -26,6 +26,10 @@ _PERIODS = {
 EXPIRATION_FUDGE = 5
 
 
+def _get_ip(request):
+    return request.META['REMOTE_ADDR']
+
+
 def ip_mask(ip):
     if ':' in ip:
         # IPv6
@@ -42,11 +46,11 @@ def ip_mask(ip):
 def user_or_ip(request):
     if request.user.is_authenticated:
         return str(request.user.pk)
-    return ip_mask(request.META['REMOTE_ADDR'])
+    return ip_mask(_get_ip(request))
 
 
 _SIMPLE_KEYS = {
-    'ip': lambda r: ip_mask(r.META['REMOTE_ADDR']),
+    'ip': lambda r: ip_mask(_get_ip(r)),
     'user': lambda r: str(r.user.pk),
     'user_or_ip': user_or_ip,
 }


### PR DESCRIPTION
Per some discussion in #208, and setting up a good place to resolve the issue raised in #209, adds a `_get_ip()` helper to `ratelimit.core`, and adds a setting to control the source of truth for the client IP address.