### PR TITLE
Fix CI and Update Tested Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,19 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
-        django: [2.2, 3.0, 3.1, master]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        django: ['2.2', '3.0', '3.1', '3.2', 'master']
         exclude:
           - python-version: 3.5
-            django: 3.0
+            django: '3.0'
           - python-version: 3.5
-            django: 3.1
+            django: '3.1'
           - python-version: 3.5
-            django: master
+            django: 'master'
           - python-version: 3.6
-            django: master
+            django: 'master'
           - python-version: 3.7
-            django: master
+            django: 'master'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
* CI testing Django 3.0 would actually only test Django 3.2 because GitHub actions converted 3.0 to an integer and tax didn't read it correctly (testing on Django 3.2a according to the logs)
* Updated Python and Django versions