### PR TITLE
Use RATELIMIT_EXCEPTION_CLASS for configuration

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -86,3 +86,9 @@ IPv4 mask for IP-based rate limit. Defaults to ``32`` (which is no masking)
 
 IPv6 mask for IP-based rate limit. Defaults to ``64`` (which mask the last 64 bits).
 Typical end site IPv6 assignment are from /48 to /64.
+
+``RATELIMIT_EXCEPTION_CLASS``
+-----------------------------
+
+A custom exception class, or a dotted path to a custom exception class, that will be
+raised by ratelimit when a limit is exceeded and ``block=True``.


### PR DESCRIPTION
Fixes #242 

A concern I have is performance. This seems like it is importing every time the view is called. I've implemented this like the rest of the package. However, I feel like this would be better if we instead made a "proxy" or global variable that we saved on first load of the class. The only problem I suppose would be dev reload.