### PR TITLE
Match Django versions to currently supported

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.5', '3.6', '3.7', '3.8', '3.9']
-        django: ['2.2', '3.0', '3.1', 'main']
+        django: ['2.2', '3.1', '3.2', 'main']
         exclude:
           - python-version: '3.5'
-            django: '3.0'
-          - python-version: '3.5'
             django: '3.1'
+          - python-version: '3.5'
+            django: '3.2'
           - python-version: '3.5'
             django: 'main'
           - python-version: '3.6'


### PR DESCRIPTION
Django 3.0 is EOL and 3.2 is out, so test 3.2 explicitly in place of
3.0. Currently testing against the primary, previous, and LTS versions:
2.2, 3.1, 3.2.