### PR TITLE
fix: `get_usage` set count value error when initialize a new key in `increment=False` situation

### DIFF
--- a/django_ratelimit/core.py
+++ b/django_ratelimit/core.py
@@ -215,7 +215,7 @@ def get_usage(request, group=None, fn=None, key=None, rate=None, method=ALL,
             'Could not understand ratelimit key: %s' % key)
 
     window = _get_window(value, period)
-    initial_value = 1 if increment else 0
+    initial_value = 1
 
     cache_name = getattr(settings, 'RATELIMIT_USE_CACHE', 'default')
     cache = caches[cache_name]


### PR DESCRIPTION
The following code section has dealt with the case of `increment=False`.
https://github.com/jsocol/django-ratelimit/blob/201d37f82e1cf31a2b21e329ed7a85726e6941f7/ratelimit/core.py#L194-L203

So the initialization is superfluous. It will cause that the times of the limit will one more time than we set. It will happen when we `check` the `ratelimit` before `check and increament` the `ratelimit`.
https://github.com/jsocol/django-ratelimit/blob/201d37f82e1cf31a2b21e329ed7a85726e6941f7/ratelimit/core.py#L183


will cause the rate limit to be unexpected and need to be initialized again with `increment=False`