### PR TITLE
Fix urls in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Framework :: Django",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-urls = {Homepage = "https://github.com/jsocol/pystatsd"}
+urls = {Homepage = "https://github.com/jsocol/django-ratelimit"}
 
 [tool.distutils.bdist_wheel]
 universal = 1


### PR DESCRIPTION
I noticed dependabot was linking to the wrong repository (pystatsd) in PRs for the recent release of django-ratelimit.

The only reference link to pystatsd I can find is here, so I'm assuming this will fix it.

(depandabot is also sourcing the wrong CHANGELOG, commit history etc.)