### PR TITLE
Adds RATELIMIT_HASH_ALGORITHM config

### DIFF
--- a/django_ratelimit/core.py
+++ b/django_ratelimit/core.py
@@ -140,7 +140,12 @@ def _make_cache_key(group, window, rate, value, methods):
             methods = ''.join(sorted([m.upper() for m in methods]))
         parts.append(methods)
     prefix = getattr(settings, 'RATELIMIT_CACHE_PREFIX', 'rl:')
-    return prefix + hashlib.md5(''.join(parts).encode('utf-8')).hexdigest()
+    attr = getattr(settings, 'RATELIMIT_HASH_ALGORITHM', hashlib.sha512)
+    algo_cls = (import_string(f'{attr}')
+                if isinstance(attr, str)
+                else attr
+                )
+    return prefix + algo_cls(''.join(parts).encode('utf-8')).hexdigest()
 
 
 def is_ratelimited(request, group=None, fn=None, key=None, rate=None,

--- a/django_ratelimit/core.py
+++ b/django_ratelimit/core.py
@@ -140,7 +140,7 @@ def _make_cache_key(group, window, rate, value, methods):
             methods = ''.join(sorted([m.upper() for m in methods]))
         parts.append(methods)
     prefix = getattr(settings, 'RATELIMIT_CACHE_PREFIX', 'rl:')
-    attr = getattr(settings, 'RATELIMIT_HASH_ALGORITHM', hashlib.sha512)
+    attr = getattr(settings, 'RATELIMIT_HASH_ALGORITHM', hashlib.sha256)
     algo_cls = (import_string(f'{attr}')
                 if isinstance(attr, str)
                 else attr

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -10,6 +10,12 @@ Settings
 An optional cache prefix for ratelimit keys (in addition to the ``PREFIX``
 value defined on the cache backend). Defaults to ``'rl:'``.
 
+``RATELIMIT_HASH_ALGORITHM``
+-----------------------------
+
+An optional functionion to overide the default hashing algorithm used to derive the cache
+key. Defaults to ``'hashlib.sha512'``.
+
 ``RATELIMIT_ENABLE``
 --------------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,9 @@ deps =
     django-redis>=5.2,<6.0
     flake8
 
+allowlist_externals =
+    */run.sh
+
 commands =
     ./run.sh test {posargs}
     ./run.sh flake8


### PR DESCRIPTION
This is just a simple update to the library that changes the default hashing off of md5. Md5 has been proven to be insecure, subject to collision attacks [[Wang](https://www.rfc-editor.org/rfc/rfc9155#Wang)]. In 2011, [[RFC6151](https://www.rfc-editor.org/rfc/rfc9155#RFC6151)] detailed the security considerations, including collision attacks for MD5. NIST formally deprecated use of SHA-1 in 2011 [[NISTSP800-131A-R2](https://www.rfc-editor.org/rfc/rfc9155#NISTSP800-131A-R2)]

This updates the hashing algorithm to an implementation without known collision issues and giving end users the option to configure the hashing function used for signature generation as their needs require. Implementation of the config check was modeled off of the decorator's check for `RATELIMIT_EXCEPTION_CLASS`

Finally, one small tweak of the tox file was needed to get tests to run locally.