### PR TITLE
Fixes the docs to show the proper default hash algorithm

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -14,7 +14,7 @@ value defined on the cache backend). Defaults to ``'rl:'``.
 -----------------------------
 
 An optional functionion to overide the default hashing algorithm used to derive the cache
-key. Defaults to ``'hashlib.sha512'``.
+key. Defaults to ``'hashlib.sha256'``.
 
 ``RATELIMIT_ENABLE``
 --------------------


### PR DESCRIPTION
Looks like I forgot to update the docs in my PR #282. This PR simply fixes the docs to reflect the proper default value for `RATELIMIT_HASH_ALGORITHM`