### PR TITLE
Add Django 4.2 to tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        django: ['3.2', '4.0', '4.1', 'main']
+        django: ['3.2', '4.1', '4.2', 'main']
         exclude:
           - python-version: '3.7'
-            django: '4.0'
-          - python-version: '3.7'
             django: '4.1'
+          - python-version: '3.7'
+            django: '4.2'
           - python-version: '3.7'
             django: 'main'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,17 @@
 [tox]
 envlist =
     py37-django32,
-    py38-django{32,40,41,main},
-    py39-django{32,40,41,main},
-    py310-django{32,40,41,main},
-    py311-django{32,40,41,main},
-    pypy39-django{32,40,41,main},
+    py38-django{32,41,42,main},
+    py39-django{32,41,42,main},
+    py310-django{32,41,42,main},
+    py311-django{32,41,42,main},
+    pypy39-django{32,41,42,main},
 
 [testenv]
 deps =
     django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<4.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
     pymemcache>=4.0,<5.0
     django-redis>=5.2,<6.0


### PR DESCRIPTION
Rotate out Django 4.0 and add 4.2 to the test suite to keep up with the
upstream releases.
