### PR TITLE
Add support for async functions to decorator

### DIFF
--- a/django_ratelimit/decorators.py
+++ b/django_ratelimit/decorators.py
@@ -1,4 +1,5 @@
 from functools import wraps
+from inspect import iscoroutinefunction
 
 from django.conf import settings
 from django.utils.module_loading import import_string
@@ -13,6 +14,23 @@ __all__ = ['ratelimit']
 
 def ratelimit(group=None, key=None, rate=None, method=ALL, block=True):
     def decorator(fn):
+        # if iscoroutinefunction(fn):
+        #     @wraps(fn)
+        #     async def _async_wrapped(request, *args, **kw):
+        #         old_limited = getattr(request, 'limited', False)
+        #         ratelimited = is_ratelimited(
+        #             request=request, group=group, fn=fn, key=key, rate=rate,
+        #             method=method, increment=True)
+        #         request.limited = ratelimited or old_limited
+        #         if ratelimited and block:
+        #             cls = getattr(
+        #                 settings, 'RATELIMIT_EXCEPTION_CLASS', Ratelimited)
+        #             if isinstance(cls, str):
+        #                 cls = import_string(cls)
+        #             raise cls()
+        #         return await fn(request, *args, **kw)
+        #     return _async_wrapped
+
         @wraps(fn)
         def _wrapped(request, *args, **kw):
             old_limited = getattr(request, 'limited', False)
@@ -23,7 +41,9 @@ def ratelimit(group=None, key=None, rate=None, method=ALL, block=True):
             if ratelimited and block:
                 cls = getattr(
                     settings, 'RATELIMIT_EXCEPTION_CLASS', Ratelimited)
-                raise (import_string(cls) if isinstance(cls, str) else cls)()
+                if isinstance(cls, str):
+                    cls = import_string(cls)
+                raise cls()
             return fn(request, *args, **kw)
         return _wrapped
     return decorator


### PR DESCRIPTION
Tries to add support for async functions to the decorator, but trips
over not having a failing test to fix.
