### PR TITLE
Fix duplicated option issue in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,10 +20,6 @@ deps =
     pymemcache>=4.0,<5.0
     django-redis>=5.2,<6.0
     flake8
-
-allowlist_externals =
-    */run.sh
-
 commands =
     ./run.sh test {posargs}
     ./run.sh flake8


### PR DESCRIPTION
When running `tox` locally I get the following error:

```txt
configparser.DuplicateOptionError: While reading from '/Users/ronan/Projects/django-ratelimit/tox.ini' [line 22]: option 'allowlist_externals' in section 'testenv' already exists
```

The option `allowlist_externals` seems indeed duplicated in `tox.ini`. If I remove the second one the tests run fine on my local environment.