### PR TITLE
Add support for Django REST Framework's Request.data

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -20,7 +20,7 @@ runs:
       python -m pip install --upgrade pip
       if [[ ${{ inputs.django-version }} != 'main' ]]; then pip install --pre -q "Django>=${{ inputs.django-version }},<${{ inputs.django-version }}.99"; fi
       if [[ ${{ inputs.django-version }} == 'main' ]]; then pip install https://github.com/django/django/archive/main.tar.gz; fi
-      pip install flake8 django-redis pymemcache
+      pip install flake8 django-redis pymemcache djangorestframework
 
   - name: Test
     shell: sh

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,11 @@ Change Log
 UNRELEASED
 ==========
 
+Additions:
+----------
+
+- Add support for rate limiting on Django REST Framework's `Request.data`
+
 v4.1
 ====
 

--- a/django_ratelimit/core.py
+++ b/django_ratelimit/core.py
@@ -81,6 +81,7 @@ def get_header(request, header):
 _ACCESSOR_KEYS = {
     'get': lambda r, k: r.GET.get(k, ''),
     'post': lambda r, k: r.POST.get(k, ''),
+    'data': lambda r, k: r.data.get(k, ''),
     'header': get_header,
 }
 

--- a/django_ratelimit/tests.py
+++ b/django_ratelimit/tests.py
@@ -8,6 +8,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import View
 
 from rest_framework.decorators import api_view
+from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory
 
 from django_ratelimit.decorators import ratelimit
@@ -160,12 +161,12 @@ class RatelimitTests(TestCase):
         @api_view(['POST'])
         @ratelimit(key='data:foo', rate='1/m', block=False)
         def view(request):
-            return request.limited
+            return Response(request.limited)
 
-        assert not view(rest_rf.post('/', {'foo': 'a'}))
-        assert view(rest_rf.post('/', {'foo': 'a'}))
-        assert not view(rest_rf.post('/', {'foo': 'b'}))
-        assert view(rest_rf.post('/', {'foo': 'b'}))
+        assert not view(rest_rf.post('/', {'foo': 'a'})).data
+        assert view(rest_rf.post('/', {'foo': 'a'})).data
+        assert not view(rest_rf.post('/', {'foo': 'b'})).data
+        assert view(rest_rf.post('/', {'foo': 'b'})).data
 
     def test_key_header(self):
         def _req():

--- a/docs/keys.rst
+++ b/docs/keys.rst
@@ -25,6 +25,7 @@ used ratelimit keys:
        <security-chapter>` notes.
 - ``'get:X'`` - Use the value of ``request.GET.get('X', '')``.
 - ``'post:X'`` - Use the value of ``request.POST.get('X', '')``.
+- ``'data:X'`` - Use the value of ``request.data.get('X', '')`` (useful for projects using Django REST Framework).
 - ``'header:x-x'`` - Use the value of
   ``request.META.get('HTTP_X_X', '')``.
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -4,6 +4,7 @@ SILENCED_SYSTEM_CHECKS = ['django_ratelimit.E003', 'django_ratelimit.W001']
 
 INSTALLED_APPS = (
     'django_ratelimit',
+    'rest_framework',
 )
 
 RATELIMIT_USE_CACHE = 'default'

--- a/test_settings.py
+++ b/test_settings.py
@@ -3,8 +3,10 @@ SECRET_KEY = 'ratelimit'
 SILENCED_SYSTEM_CHECKS = ['django_ratelimit.E003', 'django_ratelimit.W001']
 
 INSTALLED_APPS = (
-    'django_ratelimit',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
     'rest_framework',
+    'django_ratelimit',
 )
 
 RATELIMIT_USE_CACHE = 'default'

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     django42: Django>=4.2,<4.3
     django50: Django>=5.0a1,<5.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
+    djangorestframework~=3.15.1
     pymemcache>=4.0,<5.0
     django-redis>=5.2,<6.0
     flake8


### PR DESCRIPTION
Support rate limiting on the key `data` for use with Django REST Framework's [`Request.data`](https://www.django-rest-framework.org/api-guide/requests/#data)