### PR TITLE
Fix: Update 429.rst

### DIFF
--- a/docs/cookbook/429.rst
+++ b/docs/cookbook/429.rst
@@ -38,7 +38,7 @@ must define ``RATELIMIT_VIEW`` as a dotted-path to your error view:
 
     MIDDLEWARE = (
         # ... toward the bottom ...
-        'ratelimit.middleware.RatelimitMiddleware',
+        'django_ratelimit.middleware.RatelimitMiddleware',
         # ...
     )
 


### PR DESCRIPTION
Currently, the middleware in the documentation leads to the following error.
```
ModuleNotFoundError: No module named 'ratelimit'
```

Update the docs accordingly.