### PR TITLE
Skip checks when RATELIMIT_ENABLE is set to False

### DIFF
--- a/django_ratelimit/checks.py
+++ b/django_ratelimit/checks.py
@@ -22,6 +22,10 @@ KNOWN_BROKEN_CACHE_BACKENDS = {
 @checks.register(checks.Tags.caches, 'django_ratelimit')
 def check_caches(app_configs, **kwargs):
     errors = []
+
+    if not getattr(settings, 'RATELIMIT_ENABLE', True):
+        return errors
+
     cache_name = getattr(settings, 'RATELIMIT_USE_CACHE', 'default')
     caches = getattr(settings, 'CACHES', None)
     if caches is None:


### PR DESCRIPTION
These changes will allow using any cache backend for local development when enabling rate limiting is often unnecessary