### PR TITLE
Added increment_ratelimit

### DIFF
--- a/django_ratelimit/core.py
+++ b/django_ratelimit/core.py
@@ -156,13 +156,21 @@ def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
 
     return usage['should_limit']
 
-def increment_ratelimit(request, group) -> int:
+def increment_ratelimit(request, group=None, fn=None, key=None, rate=None, method=ALL) -> int:
     """
     Alias of is_ratelimited that just increments the rate limit for the given group.
 
+    Requires params:
+    - Either group or fn
+    - key (for example: ip)
+    - rate (for example: '10/m')
+
     Returns the new usage count.
     """
-    usage = get_usage(request, group, increment=True)
+    usage = get_usage(request, group, fn, key, rate, method, increment=True)
+    print(f"usage: {usage}\n")
+    if usage is None:
+        return 0
     return usage.get("count", 0)
 
 def get_usage(request, group=None, fn=None, key=None, rate=None, method=ALL,

--- a/django_ratelimit/core.py
+++ b/django_ratelimit/core.py
@@ -160,6 +160,7 @@ def increment_ratelimit(request, group=None, fn=None, key=None,
                         rate=None, method=ALL) -> int:
     """
     Alias of is_ratelimited that just increments the rate limit.
+    This increments the usage count by one, and returns the new usage count.
 
     Requires params:
     - Either group or fn
@@ -169,7 +170,7 @@ def increment_ratelimit(request, group=None, fn=None, key=None,
     Returns the new usage count.
     """
     usage = get_usage(request, group, fn, key, rate, method, increment=True)
-    print(f"usage: {usage}\n")
+
     if usage is None:
         return 0
     return usage.get("count", 0)

--- a/django_ratelimit/core.py
+++ b/django_ratelimit/core.py
@@ -156,6 +156,14 @@ def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
 
     return usage['should_limit']
 
+def increment_ratelimit(request, group) -> int:
+    """
+    Alias of is_ratelimited that just increments the rate limit for the given group.
+
+    Returns the new usage count.
+    """
+    usage = get_usage(request, group, increment=True)
+    return usage.get("count", 0)
 
 def get_usage(request, group=None, fn=None, key=None, rate=None, method=ALL,
               increment=False):

--- a/django_ratelimit/core.py
+++ b/django_ratelimit/core.py
@@ -13,7 +13,6 @@ from django.utils.module_loading import import_string
 
 from django_ratelimit import ALL, UNSAFE
 
-
 __all__ = ['is_ratelimited', 'get_usage']
 
 _PERIODS = {
@@ -156,9 +155,11 @@ def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
 
     return usage['should_limit']
 
-def increment_ratelimit(request, group=None, fn=None, key=None, rate=None, method=ALL) -> int:
+
+def increment_ratelimit(request, group=None, fn=None, key=None,
+                        rate=None, method=ALL) -> int:
     """
-    Alias of is_ratelimited that just increments the rate limit for the given group.
+    Alias of is_ratelimited that just increments the rate limit.
 
     Requires params:
     - Either group or fn
@@ -172,6 +173,7 @@ def increment_ratelimit(request, group=None, fn=None, key=None, rate=None, metho
     if usage is None:
         return 0
     return usage.get("count", 0)
+
 
 def get_usage(request, group=None, fn=None, key=None, rate=None, method=ALL,
               increment=False):

--- a/django_ratelimit/tests.py
+++ b/django_ratelimit/tests.py
@@ -9,8 +9,9 @@ from django.views.generic import View
 
 from django_ratelimit.decorators import ratelimit
 from django_ratelimit.exceptions import Ratelimited
-from django_ratelimit.core import (get_usage, is_ratelimited, increment_ratelimit,
-    _split_rate, _get_ip)
+from django_ratelimit.core import (get_usage, is_ratelimited,
+                                   increment_ratelimit, _split_rate,
+                                   _get_ip)
 
 rf = RequestFactory()
 
@@ -445,28 +446,30 @@ class FunctionsTests(TestCase):
         key = 'ip'
         group = 'a'
         method = is_ratelimited.ALL
-        increment = partial(increment_ratelimit, rate=rate, method=method, key=key, group=group)
-        check_is_ratelimited = partial(is_ratelimited, rate=rate, method=method, key=key, group=group, increment=False)
+        increment = partial(increment_ratelimit, rate=rate, method=method,
+                            key=key, group=group)
+        is_user_ratelimited = partial(is_ratelimited, rate=rate, method=method,
+                                      key=key, group=group, increment=False)
 
         # Not limited because nothing is incremented.
-        assert not check_is_ratelimited(rf.get('/'))
-        assert not check_is_ratelimited(rf.get('/'))
+        assert not is_user_ratelimited(rf.get('/'))
+        assert not is_user_ratelimited(rf.get('/'))
 
         # Make sure that the previous two didn't increment the count.
         assert increment(rf.get('/')) == 1
 
         # Still at count = 1, and 1 isn't greater than 1.
-        assert not check_is_ratelimited(rf.get('/'))
+        assert not is_user_ratelimited(rf.get('/'))
 
         assert increment(rf.get('/')) == 2
 
         # Count = 2, 2 > 1. So user is ratelimited
-        assert check_is_ratelimited(rf.get('/'))
+        assert is_user_ratelimited(rf.get('/'))
 
         # Make sure incrementing still works even after the user is ratelimited
         assert increment(rf.get('/')) == 3
 
-        assert check_is_ratelimited(rf.get('/'))
+        assert is_user_ratelimited(rf.get('/'))
 
     def test_get_usage(self):
         _get_usage = partial(get_usage, method=get_usage.ALL, key='ip',

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -217,7 +217,7 @@ functionality in ``ratelimit.core``. The two major methods are
 
 .. code-block:: python
 
-    from django_ratelimit.core import get_usage, is_ratelimited
+    from django_ratelimit.core import get_usage, is_ratelimited, increment_ratelimit
 
 .. py:function:: get_usage(request, group=None, fn=None, key=None, \
                            rate=None, method=ALL, increment=False)
@@ -299,13 +299,51 @@ functionality in ``ratelimit.core``. The two major methods are
    :returns bool:
        Whether this request should be limited or not.
 
-
 ``is_ratelimited`` is a thin wrapper around ``get_usage`` that is
 maintained for compatibility. It provides strictly less information.
 
+.. py:function:: increment_ratelimit(request, group=None, fn=None, \
+                                key=None, rate=None, method=ALL)
+
+   :arg request:
+       *None* The HTTPRequest object.
+
+   :arg group:
+       *None* A group of rate limits to count together. Defaults to the
+       dotted name of the view.
+
+   :arg fn:
+       *None* A view function which can be used to calculate the group
+       as if it was decorated by :ref:`@ratelimit <usage-decorator>`.
+
+   :arg key:
+       What key to use, see :ref:`Keys <keys-chapter>`.
+
+   :arg rate:
+       *'5/m'* The number of requests per unit time allowed. Valid
+       units are:
+
+       * ``s`` - seconds
+       * ``m`` - minutes
+       * ``h`` - hours
+       * ``d`` - days
+
+       Also accepts callables. See :ref:`Rates <rates-chapter>`.
+
+   :arg method:
+       *ALL* Which HTTP method(s) to rate-limit. May be a string, a
+       list/tuple, or ``None`` for all methods.
+
+   :returns int:
+       The count of the requests in the specified unit time allowed (rate)
+
+
+``increment_ratelimit`` is an alias of is_ratelimited that is also a thin wrapper around ``get_usage`` that is
+maintained for compatibility. It provides strictly less information, and only increments the rate limit count.
+
 .. warning::
     
-    ``get_usage`` and ``is_ratelimited`` require either ``group=`` or
+    ``get_usage``, ``is_ratelimited`` and ``increment_ratelimit`` require either ``group=`` or
     ``fn=`` to be passed, or they cannot determine the rate limiting
     state and will throw.
 


### PR DESCRIPTION
I added an `increment_ratelimit` function to just increment the group ratelimit count.
This is practically just an alias of `is_ratelimited` but makes more sense in terms of its name. Takes only request and group (should I add keys, and fn too?) and returns the count of limits on return (can be a boolean True if successful instead if preferred). This was suggested in #308 as it makes more logical sense to call a function to "increment" the ratelimit rather than call "is_ratelimited" if you're just incrementing it.

Where would this be useful?
Well in situations like unsuccessful login attempts, in the logic for your function you may want to add 1 to the count (in this case you dont use decorators), so you need to call a function. 

```py
increment_ratelimit("unsuccessful_login")
```
This snippet makes a little more sense then this snippet (logically)

```py
is_ratelimited(request, group="unsuccessful_login", key="ip", rate="5/5m", increment=True)
```

Closes issue: #308