### PR TITLE
Adds get_usage_extended and the ability to add usage_details to Ratelimited exception

### DIFF
--- a/django_ratelimit/core.py
+++ b/django_ratelimit/core.py
@@ -158,14 +158,14 @@ def is_ratelimited(request, group=None, fn=None, key=None, rate=None,
 def get_usage(request, group=None, fn=None, key=None, rate=None, method=ALL,
               increment=False):
     """
-    Call get_usage_extended and strip out internal_values for backwards compatibility.
+    Call get_usage_extended and strip out usage_details for backwards compatibility.
     """
     usage = get_usage_extended(request, group, fn, key, rate, method, increment)
     if usage is None:
         return None
     return {
         result_key: usage[result_key] for result_key in usage
-        if result_key != 'internal_values'
+        if result_key != 'usage_details'
     }
 
 
@@ -280,7 +280,7 @@ def get_usage_extended(request, group=None, fn=None, key=None, rate=None, method
             'limit': 0,
             'should_limit': True,
             'time_left': -1,
-            'internal_values': usage_details,
+            'usage_details': usage_details,
         }
 
     time_left = window - int(time.time())
@@ -289,7 +289,7 @@ def get_usage_extended(request, group=None, fn=None, key=None, rate=None, method
         'limit': limit,
         'should_limit': count > limit,
         'time_left': time_left,
-        'internal_values': usage_details,
+        'usage_details': usage_details,
     }
 
 

--- a/django_ratelimit/exceptions.py
+++ b/django_ratelimit/exceptions.py
@@ -1,5 +1,19 @@
+import json
+
 from django.core.exceptions import PermissionDenied
+from django.core.serializers.json import DjangoJSONEncoder
 
 
 class Ratelimited(PermissionDenied):
-    pass
+
+    def __init__(self, *args, usage=None, **kwargs):
+        self.usage = usage
+        super().__init__(*args, **kwargs)
+        # If python >=3.11 (has add_note), then add jsonified self.usage as note
+        if hasattr(self, "add_note"):
+            self.add_note("Usage: " + json.dumps(
+                self.usage,
+                indent=2,
+                cls=DjangoJSONEncoder,
+                default=lambda obj: str(obj),
+            ))


### PR DESCRIPTION
This change makes it easier to implement a custom decorator that passes usage_details to the exception.

Example:
```python
def ratelimit(group=None, key=None, rate=None, method=ALL, block=True):
    def decorator(fn):
        @wraps(fn)
        def _wrapped(request, *args, **kw):
            old_limited = getattr(request, 'limited', False)
            usage = get_usage_extended(
                request=request,
                group=group,
                fn=fn,
                key=key,
                rate=rate,
                method=method,
                increment=True
            )
            ratelimited = usage['should_limit'] if usage else False
            request.limited = ratelimited or old_limited
            if ratelimited and block:
                cls = getattr(
                    settings, 'RATELIMIT_EXCEPTION_CLASS', Ratelimited)
                raise (import_string(cls) if isinstance(cls, str) else cls)(usage=usage)
            return fn(request, *args, **kw)

        return _wrapped

    return decorator
```