### PR TITLE
Update `usage.rst` in document

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -66,12 +66,12 @@ the root ``ratelimit`` module:
 
     from django_ratelimit.decorators import ratelimit
 
-    @ratelimit(key='ip', method=ratelimit.ALL)
-    @ratelimit(key='ip', method=ratelimit.UNSAFE)
+    @ratelimit(key='ip', method=django_ratelimit.ALL)
+    @ratelimit(key='ip', method=django_ratelimit.UNSAFE)
     def myview(request):
         pass
 
-``ratelimit.ALL`` applies to all HTTP methods. ``ratelimit.UNSAFE``
+``django_ratelimit.ALL`` applies to all HTTP methods. ``django_ratelimit.UNSAFE``
 is a shortcut for ``('POST', 'PUT', 'PATCH', 'DELETE')``.
 
 


### PR DESCRIPTION
In the **"Using Django Ratelimit"** section of the original document, it is explained that the decorator can limit HTTP methods. `ratelimt.All` represents all HTTP methods, and `ratelimit.UNSAFE` represents `('POST', 'PUT', 'PATCH', 'DELETE')`. However, when upgrading from version 3.x to 4.0, imports should be renamed from `from ratelimit` to `from django_ratelimit`, so the document needs to be updated.