### PR TITLE
Annotate request and exception with usage data

### DIFF
--- a/django_ratelimit/decorators.py
+++ b/django_ratelimit/decorators.py
@@ -5,7 +5,7 @@ from django.utils.module_loading import import_string
 
 from django_ratelimit import ALL, UNSAFE
 from django_ratelimit.exceptions import Ratelimited
-from django_ratelimit.core import is_ratelimited
+from django_ratelimit.core import get_usage
 
 
 __all__ = ['ratelimit']
@@ -16,14 +16,24 @@ def ratelimit(group=None, key=None, rate=None, method=ALL, block=True):
         @wraps(fn)
         def _wrapped(request, *args, **kw):
             old_limited = getattr(request, 'limited', False)
-            ratelimited = is_ratelimited(request=request, group=group, fn=fn,
-                                         key=key, rate=rate, method=method,
-                                         increment=True)
+
+            usage = get_usage(request=request, group=group, fn=fn,
+                              key=key, rate=rate, method=method,
+                              increment=True)
+            if usage is None:
+                ratelimited = False
+            else:
+                ratelimited = usage['should_limit']
+
             request.limited = ratelimited or old_limited
+            request.usage = usage
+
             if ratelimited and block:
                 cls = getattr(
                     settings, 'RATELIMIT_EXCEPTION_CLASS', Ratelimited)
-                raise (import_string(cls) if isinstance(cls, str) else cls)()
+                exc = (import_string(cls) if isinstance(cls, str) else cls)()
+                exc.usage = usage
+                raise exc
             return fn(request, *args, **kw)
         return _wrapped
     return decorator


### PR DESCRIPTION
This can e.g. be inspected by Django's exception handler to give an API user feedback about how long to wait until they may try again.

Usage data will be available as:
- `request.usage`
- `<settings.RATELIMIT_EXCEPTION_CLASS>().usage`

So inside my view or exception handler I could format `time_left` into a more helpful feedback text for the users of my API.